### PR TITLE
Bugfix for modal popup / scrollbar

### DIFF
--- a/src/factory.css
+++ b/src/factory.css
@@ -634,7 +634,7 @@ td.taboff:hover {
   position: absolute;
   top: 0;
   width: 60%;
-  z-index:2;
+  z-index:20;
 }
 
 #popup #bkg {


### PR DESCRIPTION
Fixed z-index so that scrollbar is not above the popup. (Issue #29)

This isn't the best fix (I think it's worth investigating what exactly the z-index of Blockly workspaces are), but it fixes the minor "bug" for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/47)
<!-- Reviewable:end -->
