### PR TITLE
Closure-library as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ npm-debug.log
 *.pyc
 *.komodoproject
 /nbproject/private/
-closure-library
 node_modules
 package-lock.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "closure-library"]
+	path = closure-library
+	url = https://github.com/google/closure-library.git
+	branch = npm-v20170521.0.0


### PR DESCRIPTION
Using a [git submodule](https://git-scm.com/docs/git-submodule) to pull in the [closure-library](https://github.com/google/closure-library) [npm-v20170521.0.0 branch](https://github.com/google/closure-library/tree/npm-v20170521.0.0).

You will need to delete you local copy of closure-library before pulling this update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/58)
<!-- Reviewable:end -->
