### PR TITLE
Removed duplicate function in FactoryUtils

### DIFF
--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -1153,23 +1153,3 @@ FactoryUtils.bindClick = function(element, func) {
   element.addEventListener('click', func, true);
   element.addEventListener('touchend', func, true);
 };
-
-/**
- * Creates a file and downloads it. In some browsers downloads, and in other
- * browsers, opens new tab with contents.
- * @param {string} filename Name of file
- * @param {!Blob} data Blob containing contents to download
- */
-FactoryUtils.createAndDownloadFile = function(filename, data) {
-  // Moved in from wfactory_view.js
-  var clickEvent = new MouseEvent('click', {
-    'view': window,
-    'bubbles': true,
-    'cancelable': false
-  });
-  var a = document.createElement('a');
-  a.href = window.URL.createObjectURL(data);
-  a.download = filename;
-  a.textContent = 'Download file!';
-  a.dispatchEvent(clickEvent);
-};


### PR DESCRIPTION
There are two `createAndDownloadFile()` functions in FactoryUtils that differ by one line. Basically duplicates. Removed one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/88)
<!-- Reviewable:end -->
