### PR TITLE
Block Editor: Creating Blocks

### DIFF
--- a/app.html
+++ b/app.html
@@ -27,7 +27,6 @@
     <!--div id="blocklibraryExporter_tab" class="tab taboff">Block Exporter</div-->
     <div id="toolboxEditor_tab" class="tab taboff">Toolbox Editor</div>
     <div id="workspaceEditor_tab" class="tab taboff">Workspace Editor</div>
-    <div id="exporter_tab" class="tab taboff">Exporter</div>
   </div>
 
   <!-- Blockly Factory Tab -->

--- a/app.html
+++ b/app.html
@@ -27,7 +27,7 @@
     <!--div id="blocklibraryExporter_tab" class="tab taboff">Block Exporter</div-->
     <div id="toolboxEditor_tab" class="tab taboff">Toolbox Editor</div>
     <div id="workspaceEditor_tab" class="tab taboff">Workspace Editor</div>
-    <div id="workspaceFactory_tab" class="tab taboff">Workspace Factory</div>
+    <div id="exporter_tab" class="tab taboff">Exporter</div>
   </div>
 
   <!-- Blockly Factory Tab -->

--- a/src/controller/app_controller.js
+++ b/src/controller/app_controller.js
@@ -104,7 +104,7 @@ class AppController {
      * @type {!EditorController}
      */
     this.editorController = new EditorController(
-        this.project, this.hiddenWorkspace, this.navTree);
+        this.projectController, this.hiddenWorkspace);
 
     /**
      * Main View class which manages view portion of application.

--- a/src/controller/app_controller.js
+++ b/src/controller/app_controller.js
@@ -103,7 +103,8 @@ class AppController {
      * EditorController object which encapsulates all editor controllers
      * @type {!EditorController}
      */
-    this.editorController = new EditorController(this.project, this.hiddenWorkspace);
+    this.editorController = new EditorController(
+        this.project, this.hiddenWorkspace, this.navTree);
 
     /**
      * Main View class which manages view portion of application.

--- a/src/controller/app_controller.js
+++ b/src/controller/app_controller.js
@@ -97,7 +97,7 @@ class AppController {
      * ProjectController object associated with application.
      * @type {!ProjectController}
      */
-    this.projectController = new ProjectController(this.project, this.tree);
+    this.projectController = new ProjectController(this.project, this.navTree);
 
     /**
      * EditorController object which encapsulates all editor controllers

--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -126,7 +126,7 @@ class BlockEditorController {
   }
 
   /**
-   * Updates blockType and XML of BlockDefinition.
+   * Updates blockType and XML of currently open BlockDefinition.
    * @private
    */
   updateBlockDef_() {
@@ -250,9 +250,7 @@ class BlockEditorController {
     }
 
     if (format == BlockEditorController.FORMAT_JSON) {
-      console.log('json format detected!');
       var json = JSON.parse(code);
-      console.log('json type: ' + json.type);
       Blockly.Blocks[json.type || 'unnamed'] = {
         init: function() {
           this.jsonInit(json);

--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -45,24 +45,20 @@ class BlockEditorController {
    * @param {!NavigationTree} navTree Navigation tree that will be updated after
    *     changes in this editor.
    */
-  constructor(project, hiddenWorkspace, navTree) {
+  constructor(projectController, hiddenWorkspace) {
     /**
-     * Project whose library is controlled by this BlockEditorController instance.
-     * @type {!Project}
+     * ProjectController to make changes to libraries when edited in the block
+     *     editor.
+     * @type {!ProjectController}
      */
-    this.project = project;
-
-    /**
-     * Navigation tree that displays all resources in this Project.
-     * @type {!NavigationTree}
-     */
-    this.navTree = navTree;
+    this.projectController = projectController;
 
     // Creates a default library. Adds a sample block to library.
     const firstLibrary = new BlockLibrary('MyFirstLibrary');
     this.project.addBlockLibrary(firstLibrary);
     const firstBlock = new BlockDefinition('block_type');
     firstLibrary.addBlockDefinition(firstBlock);
+    this.navTree.addBlockLibraryNode('MyFirstLibrary');
 
     /**
      * View object in charge of visible elements of DevTools Block Library editor.
@@ -86,7 +82,10 @@ class BlockEditorController {
 
     this.refreshPreviews();
 
-    this.view.editorWorkspace.addChangeListener(() => { this.refreshPreviews(); });
+    // Refresh previews on workspace change.
+    this.view.editorWorkspace.addChangeListener(() => {
+      this.refreshPreviews();
+    });
   }
 
   /**
@@ -214,6 +213,7 @@ class BlockEditorController {
    * @private
    */
   updateNavTree_() {
+    console.log('updateNavTree_()');
     this.navTree.addBlockNode(this.getType_(), 'MyFirstLibrary');
   }
 

--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -54,11 +54,9 @@ class BlockEditorController {
     this.projectController = projectController;
 
     // Creates a default library. Adds a sample block to library.
-    const firstLibrary = new BlockLibrary('MyFirstLibrary');
-    this.project.addBlockLibrary(firstLibrary);
+    this.projectController.createBlockLibrary('MyFirstLibrary');
     const firstBlock = new BlockDefinition('block_type');
-    firstLibrary.addBlockDefinition(firstBlock);
-    this.navTree.addBlockLibraryNode('MyFirstLibrary');
+    this.projectController.addBlockDefinition(firstBlock, 'MyFirstLibrary');
 
     /**
      * View object in charge of visible elements of DevTools Block Library editor.
@@ -110,9 +108,8 @@ class BlockEditorController {
     const format = $('#format').val();
     this.updateBlockDefinitionView_(format);
     this.updatePreview_();
-    this.updateGenerator_(this.getPreviewBlock_());
+    this.updateGenerator_();
     this.updateBlockDef_();
-    this.updateNavTree_();
   }
 
   /**
@@ -138,19 +135,20 @@ class BlockEditorController {
    */
   updateBlockDef_() {
     const rootBlock = FactoryUtils.getRootBlock(this.view.editorWorkspace);
+    this.projectController.renameBlockDefinition(
+        this.view.blockDefinition.type(), rootBlock.getFieldValue('NAME'));
     this.view.blockDefinition.setXml(Blockly.Xml.blockToDom(rootBlock));
-    this.view.blockDefinition.setType(rootBlock.getFieldValue('NAME'));
   }
 
   /**
    * Update the generator code.
-   * @param {!Blockly.Block} block Rendered block in preview workspace.
    * @private
    */
-  updateGenerator_(block) {
+  updateGenerator_() {
     // REFACTORED: Moved in from factory.js:updateGenerator()
     const language = $('#language').val();
-    const generatorStub = FactoryUtils.getGeneratorStub(block, language);
+    const generatorStub = FactoryUtils.getGeneratorStub(
+        this.getPreviewBlock_(), language);
     this.view.updateGenStub(generatorStub);
   }
 
@@ -205,16 +203,6 @@ class BlockEditorController {
     } finally {
       Blockly.Blocks = backupBlocks;
     }
-  }
-
-  /**
-   * Updates navigation tree when block definition has been changed by user in
-   * block editor.
-   * @private
-   */
-  updateNavTree_() {
-    console.log('updateNavTree_()');
-    this.navTree.addBlockNode(this.getType_(), 'MyFirstLibrary');
   }
 
   /**

--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -39,11 +39,10 @@ goog.require('StandardCategories');
 class BlockEditorController {
   /**
    * @constructor
-   * @param {!Project} project Project object associated with this controller.
+   * @param {!ProjectController} projectController ProjectController used to
+   *     make changes to project after user interacts with editor.
    * @param {!Blockly.Workspace} hiddenWorkspace Invisible Blockly Workspace
    *     used to generate Blockly objects for import/export.
-   * @param {!NavigationTree} navTree Navigation tree that will be updated after
-   *     changes in this editor.
    */
   constructor(projectController, hiddenWorkspace) {
     /**
@@ -100,9 +99,7 @@ class BlockEditorController {
   }
 
   /**
-   * Refreshes all three previews (block preview, block definition view, and
-   * generator stub) at once. Also updates the model side (BlockDefinition
-   * object.)
+   * Refreshes previews in view and updates model.
    */
   refreshPreviews() {
     const format = $('#format').val();
@@ -129,8 +126,7 @@ class BlockEditorController {
   }
 
   /**
-   * Updates model side of block definition. Updates the type field and the
-   * XML.
+   * Updates blockType and XML of BlockDefinition.
    * @private
    */
   updateBlockDef_() {
@@ -155,6 +151,7 @@ class BlockEditorController {
   /**
    * Updates the Block Definition textarea with proper JSON or JavaScript.
    * @param {string} format Format of block definition. Either 'JSON' or 'JavaScript'.
+   * @private
    */
   updateBlockDefinitionView_(format) {
     const currentBlock = this.view.blockDefinition;
@@ -310,7 +307,7 @@ class BlockEditorController {
   }
 
   /**
-   * Gets the block type name that is currently being edited. Extracts type from
+   * Gets the block type that is currently being edited. Extracts type from
    * field input in 'factory_base' block.
    * @return {string} Block type of currently edited block.
    * @private

--- a/src/controller/editor_controller.js
+++ b/src/controller/editor_controller.js
@@ -36,43 +36,38 @@ goog.require('WorkspaceController');
 class EditorController {
   /**
    * @constructor
-   * @param {!Project} project Project object associated with this controller.
+   * @param {!ProjectController} projectController ProjectController used to
+   *     update the project upon changes in any editor.
    * @param {!Blockly.Workspace} hiddenWorkspace Invisible Blockly Workspace
    *     used to generate Blockly objects for import/export.
-   * @param {!NavigationTree} navTree Navigation tree that displays the resources
-   *     in the current Project.
    */
-  constructor(project, hiddenWorkspace, navTree) {
+  constructor(projectController, hiddenWorkspace) {
     /**
-     * Project object whose components are controlled by EditorController.
-     * @type {!Project}
+     * ProjectController which controls changes to this Project.
+     * @type {!ProjectController}
      */
-    this.project = project;
-
-    /**
-     * Navigation tree for current Project.
-     * @type {!NavigationTree}
-     */
-    this.navTree = navTree;
+    this.projectController = projectController;
 
     /**
      * Block Editor Controller
      * @type {BlockLibraryController}
      */
     this.blockEditorController = new BlockEditorController(
-        this.project, hiddenWorkspace, this.navTree);
+        this.projectController, hiddenWorkspace);
 
     /**
      * Toolbox Controller.
      * @type {!ToolboxController}
      */
-    this.toolboxController = new ToolboxController(this.project, hiddenWorkspace);
+    this.toolboxController = new ToolboxController(
+        this.projectController, hiddenWorkspace);
 
     /**
      * Workspace Controller.
      * @type {!WorkspaceController}
      */
-    this.workspaceController = new WorkspaceController(this.project, hiddenWorkspace);
+    this.workspaceController = new WorkspaceController(
+        this.projectController, hiddenWorkspace);
 
     /**
      * Controller object which is currently controlling the developer's application.

--- a/src/controller/editor_controller.js
+++ b/src/controller/editor_controller.js
@@ -43,7 +43,7 @@ class EditorController {
    */
   constructor(projectController, hiddenWorkspace) {
     /**
-     * ProjectController which controls changes to this Project.
+     * ProjectController which controls changes to the Project.
      * @type {!ProjectController}
      */
     this.projectController = projectController;

--- a/src/controller/editor_controller.js
+++ b/src/controller/editor_controller.js
@@ -49,21 +49,24 @@ class EditorController {
     this.projectController = projectController;
 
     /**
-     * Block Editor Controller
+     * Controls the block editor. Manages updates to model and view within
+     * block editor.
      * @type {BlockLibraryController}
      */
     this.blockEditorController = new BlockEditorController(
         this.projectController, hiddenWorkspace);
 
     /**
-     * Toolbox Controller.
+     * Controls the toolbox editor. Manages updates to model and view within
+     * toolbox editor.
      * @type {!ToolboxController}
      */
     this.toolboxController = new ToolboxController(
         this.projectController, hiddenWorkspace);
 
     /**
-     * Workspace Controller.
+     * Controls the workspace editor. Manages updates to model and view within
+     * workspace editor.
      * @type {!WorkspaceController}
      */
     this.workspaceController = new WorkspaceController(

--- a/src/controller/editor_controller.js
+++ b/src/controller/editor_controller.js
@@ -39,13 +39,28 @@ class EditorController {
    * @param {!Project} project Project object associated with this controller.
    * @param {!Blockly.Workspace} hiddenWorkspace Invisible Blockly Workspace
    *     used to generate Blockly objects for import/export.
+   * @param {!NavigationTree} navTree Navigation tree that displays the resources
+   *     in the current Project.
    */
-  constructor(project, hiddenWorkspace) {
+  constructor(project, hiddenWorkspace, navTree) {
     /**
      * Project object whose components are controlled by EditorController.
      * @type {!Project}
      */
     this.project = project;
+
+    /**
+     * Navigation tree for current Project.
+     * @type {!NavigationTree}
+     */
+    this.navTree = navTree;
+
+    /**
+     * Block Editor Controller
+     * @type {BlockLibraryController}
+     */
+    this.blockEditorController = new BlockEditorController(
+        this.project, hiddenWorkspace, this.navTree);
 
     /**
      * Toolbox Controller.
@@ -58,12 +73,6 @@ class EditorController {
      * @type {!WorkspaceController}
      */
     this.workspaceController = new WorkspaceController(this.project, hiddenWorkspace);
-
-    /**
-     * Block Editor Controller
-     * @type {BlockLibraryController}
-     */
-    this.blockEditorController = new BlockEditorController(this.project, hiddenWorkspace);
 
     /**
      * Controller object which is currently controlling the developer's application.

--- a/src/controller/project_controller.js
+++ b/src/controller/project_controller.js
@@ -83,6 +83,15 @@ class ProjectController {
   }
 
   /**
+   * Creates and adds new BlockDefinition to a given BlockLibrary.
+   * @param {string} blockType Name of block to be added.
+   * @param {string} libraryname Name of library block will be added to.
+   */
+  createBlockDefinition(blockType, libraryName) {
+    console.warn('Unimplemented: createBlockDefinition()');
+  }
+
+  /**
    * Creates and adds new toolbox to this.project's toolbox set.
    *
    * @param {string} toolboxName Name of the toolbox to add to the project.
@@ -140,6 +149,15 @@ class ProjectController {
     const blockLibrary = new BlockLibrary(blockLibraryName);
     this.addBlockLibrary(blockLibrary);
     return blockLibrary;
+  }
+
+  /**
+   * Adds BlockDefinition to a given BlockLibrary.
+   * @param {string} block BlockDefinition to be added.
+   * @param {string} libraryname Name of library block will be added to.
+   */
+  addBlockDefinition(block, libraryName) {
+    console.warn('Unimplemented: addBlockDefinition()');
   }
 
   /**
@@ -225,6 +243,15 @@ class ProjectController {
   removeBlockLibrary(blockLibraryName) {
     this.project.removeBlockLibrary(blockLibraryName);
     this.tree.deleteBlockLibraryNode(blockLibraryName);
+  }
+
+  /**
+   * Renames a block definition.
+   * @param {string} oldName Original type name of BlockDefintion object to change.
+   * @param {string} newName New type name of BlockDefinition object.
+   */
+  renameBlockDefinition(oldName, newName) {
+    console.warn('Unimplemented: renameBlockDefinition()');
   }
 
   /**

--- a/src/controller/project_controller.js
+++ b/src/controller/project_controller.js
@@ -83,18 +83,6 @@ class ProjectController {
   }
 
   /**
-   * Creates and adds new BlockDefinition to a given BlockLibrary.
-   * @param {string} blockType Name of block to be added.
-   * @param {string} libraryname Name of library block will be added to.
-   */
-  createBlockDefinition(blockType, libraryName) {
-    const library = this.project.getLibrary(libraryName);
-    // TODO(#105): Check if blockType is a valid name.
-    const block = new BlockDefinition(blockType);
-    this.addBlockDefinition(block);
-  }
-
-  /**
    * Creates and adds new toolbox to this.project's toolbox set.
    *
    * @param {string} toolboxName Name of the toolbox to add to the project.
@@ -152,16 +140,6 @@ class ProjectController {
     const blockLibrary = new BlockLibrary(blockLibraryName);
     this.addBlockLibrary(blockLibrary);
     return blockLibrary;
-  }
-
-  /**
-   * Adds BlockDefinition to a given BlockLibrary.
-   * @param {string} block BlockDefinition to be added.
-   * @param {string} libraryname Name of library block will be added to.
-   */
-  addBlockDefinition(block, libraryName) {
-    const library = this.project.getLibrary(libraryName);
-    library.addBlockDefinition(block);
   }
 
   /**
@@ -247,19 +225,6 @@ class ProjectController {
   removeBlockLibrary(blockLibraryName) {
     this.project.removeBlockLibrary(blockLibraryName);
     this.tree.deleteBlockLibraryNode(blockLibraryName);
-  }
-
-  /**
-   * Renames a block definition.
-   * @param {string} oldName Original type name of BlockDefintion object to change.
-   * @param {string} newName New type name of BlockDefinition object.
-   */
-  renameBlockDefinition(oldName, newName) {
-    if (this.project.hasBlock(oldName)) {
-      const block = this.project.getBlock(oldName);
-      // TODO(#105): Check if newName is a valid name.
-      block.setType(newName);
-    }
   }
 
   /**

--- a/src/controller/project_controller.js
+++ b/src/controller/project_controller.js
@@ -88,7 +88,10 @@ class ProjectController {
    * @param {string} libraryname Name of library block will be added to.
    */
   createBlockDefinition(blockType, libraryName) {
-    console.warn('Unimplemented: createBlockDefinition()');
+    const library = this.project.getLibrary(libraryName);
+    // TODO(#105): Check if blockType is a valid name.
+    const block = new BlockDefinition(blockType);
+    this.addBlockDefinition(block);
   }
 
   /**
@@ -157,7 +160,8 @@ class ProjectController {
    * @param {string} libraryname Name of library block will be added to.
    */
   addBlockDefinition(block, libraryName) {
-    console.warn('Unimplemented: addBlockDefinition()');
+    const library = this.project.getLibrary(libraryName);
+    library.addBlockDefinition(block);
   }
 
   /**
@@ -251,7 +255,11 @@ class ProjectController {
    * @param {string} newName New type name of BlockDefinition object.
    */
   renameBlockDefinition(oldName, newName) {
-    console.warn('Unimplemented: renameBlockDefinition()');
+    if (this.project.hasBlock(oldName)) {
+      const block = this.project.getBlock(oldName);
+      // TODO(#105): Check if newName is a valid name.
+      block.setType(newName);
+    }
   }
 
   /**

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -32,12 +32,13 @@ goog.require('ToolboxEditorView');
  * @authors sagev (Sage Vouse), celinechoo (Celine Choo), evd2014 (Emma Dauterman)
  */
 class ToolboxController {
-  constructor(project, hiddenWorkspace) {
+  constructor(projectController, hiddenWorkspace) {
     /**
-     * Project whose library is controlled by this BlockLibraryController instance.
-     * @type {!Project}
+     * ProjectController that will edit toolboxes when edited in the toolbox
+     *     editor.
+     * @type {!ProjectController}
      */
-    this.project = project;
+    this.projectController = projectController;
 
     /**
      * Keeps track of which toolbox is currently being edited.
@@ -307,7 +308,7 @@ class ToolboxController {
    */
   updateEditorToolbox() {
     const newToolboxXml = FactoryUtils.updateBlockLibCategory(
-        this.project, this.hiddenWorkspace);
+        this.projectController.getProject(), this.hiddenWorkspace);
     this.view.updateEditorToolbox(newToolboxXml);
   }
 

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -38,15 +38,17 @@ goog.require('WorkspaceEditorView');
 class WorkspaceController {
   /**
    * @constructor
-   * @param {!Project} project Project whose Workspace elements are managed by this controller.
+   * @param {!ProjectController} projectController ProjectController that will
+   *     make changes to WorkspaceContents and WorkspaceConfiguration when
+   *     edited in the workspace editor.
    * @param {!Blockly.Workspace} hiddenWorkspace Hidden workspace used to generate Blockly objects.
    */
-  constructor(project, hiddenWorkspace) {
+  constructor(projectController, hiddenWorkspace) {
     /**
-     * Project whose library is controlled by this BlockLibraryController instance.
-     * @type {!Project}
+     * ProjectController which will be used on modification of workspace objects.
+     * @type {!ProjectController}
      */
-    this.project = project;
+    this.projectController = projectController;
 
     /**
      * Keeps track of what WorkspaceContents is currently being edited.
@@ -145,7 +147,7 @@ class WorkspaceController {
    */
   updateEditorToolbox() {
     const newToolboxXml = FactoryUtils.updateBlockLibCategory(
-        this.project, this.hiddenWorkspace);
+        this.projectController.getProject(), this.hiddenWorkspace);
     this.view.updateEditorToolbox(newToolboxXml);
   }
 

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -37,14 +37,14 @@ goog.provide('FactoryUtils');
 
 /**
  * Get block definition code for the current block.
- * @param {string} blockType Type of block.
  * @param {string} format 'JSON' or 'JavaScript'.
  * @param {!Blockly.Workspace} workspace Where the root block lives.
  * @return {string} Block definition.
  */
-FactoryUtils.getBlockDefinition = function(blockType, format, workspace) {
-  blockType = FactoryUtils.cleanBlockType(blockType);
+FactoryUtils.getBlockDefinition = function(format, workspace) {
   const rootBlock = FactoryUtils.getRootBlock(workspace);
+  const blockType = FactoryUtils.cleanBlockType(rootBlock.getFieldValue('NAME'));
+  console.log(blockType);
   switch (format) {
     case 'JSON':
       var code = FactoryUtils.formatJson_(blockType, rootBlock);

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -44,7 +44,6 @@ goog.provide('FactoryUtils');
 FactoryUtils.getBlockDefinition = function(format, workspace) {
   const rootBlock = FactoryUtils.getRootBlock(workspace);
   const blockType = FactoryUtils.cleanBlockType(rootBlock.getFieldValue('NAME'));
-  console.log(blockType);
   switch (format) {
     case 'JSON':
       var code = FactoryUtils.formatJson_(blockType, rootBlock);

--- a/src/model/block_definition.js
+++ b/src/model/block_definition.js
@@ -52,6 +52,14 @@ class BlockDefinition extends Resource {
   }
 
   /**
+   * Sets type of BlockDefinition to new name.
+   * @param {string} type New type name of block.
+   */
+  setType(type) {
+    this.name = type;
+  }
+
+  /**
    * Returns a block's JSON representation.
    * @return {!Object} JSON representation of the block.
    */

--- a/src/model/project.js
+++ b/src/model/project.js
@@ -226,6 +226,17 @@ class Project extends Resource {
   }
 
   /**
+   * Returns BlockDefinition object with given type name. Does not need library
+   * name specification.
+   * @param {string} blockType Name of BlockDefinition object.
+   * @param {BlockDefinition} BlockDefinition object with given name.
+   */
+  getBlock(blockType) {
+    const allBlocks = this.librarySet.getAllBlockDefinitionsMap();
+    return allBlocks[blockType];
+  }
+
+  /**
    * Gets a named toolbox contained within the project.
    * @param {string} toolboxName The name of the toolbox to be found.
    * @return {!Toolbox} The found toolbox or null.

--- a/src/view/navigation_tree.js
+++ b/src/view/navigation_tree.js
@@ -121,7 +121,7 @@ class NavigationTree {
      * NOTE: The libraryName is the given prefix due to the assumption that
      *     blocktypes are unique across all libraries in the project.
      */
-    addComponentNode(BLOCK_PREFIX, blockType, libraryName);
+    this.addComponentNode(BLOCK_PREFIX, blockType, libraryName);
   }
 
   /**
@@ -130,7 +130,7 @@ class NavigationTree {
    * @param {string} toolboxName Name of the toolbox to add to the tree.
    */
   addToolboxNode(toolboxName) {
-    addComponentNode(TOOLBOX_PREFIX, toolboxName, this.project.name);
+    this.addComponentNode(TOOLBOX_PREFIX, toolboxName, this.project.name);
   }
 
   /**
@@ -140,7 +140,7 @@ class NavigationTree {
    *     add to the tree.
    */
   addWorkspaceContentsNode(workspaceContentsName) {
-    addComponentNode(WORKSPACE_CONTENTS_PREFIX, workspaceContentsName,
+    this.addComponentNode(WORKSPACE_CONTENTS_PREFIX, workspaceContentsName,
         this.project.name);
   }
 
@@ -151,7 +151,7 @@ class NavigationTree {
    *     to add to the tree.
    */
   addWorkspaceConfigurationNode(workspaceConfigName) {
-    addComponentNode(WORKSPACE_CONFIG_PREFIX, workspaceConfigName,
+    this.addComponentNode(WORKSPACE_CONFIG_PREFIX, workspaceConfigName,
         this.project.name);
   }
 
@@ -161,7 +161,7 @@ class NavigationTree {
    * @param {string} libraryName Name of BlockLibrary to add to the tree.
    */
   addBlockLibraryNode(libraryName) {
-    addComponentNode(LIBRARY_PREFIX, libraryName, this.project.name);
+    this.addComponentNode(LIBRARY_PREFIX, libraryName, this.project.name);
   }
 
   /**
@@ -189,7 +189,7 @@ class NavigationTree {
    * @param {string} blockType The name of the block to be removed.
    */
   deleteBlockNode(blockType) {
-    deleteComponentNode(BLOCK_PREFIX, blockType);
+    this.deleteComponentNode(BLOCK_PREFIX, blockType);
   }
 
   /**
@@ -198,7 +198,7 @@ class NavigationTree {
    * @param {string} toolboxName Name of the toolbox to remove from the tree.
    */
   deleteToolboxNode(toolboxName) {
-    deleteComponentNode(TOOLBOX_PREFIX, toolboxName);
+    this.deleteComponentNode(TOOLBOX_PREFIX, toolboxName);
   }
 
   /**
@@ -208,7 +208,7 @@ class NavigationTree {
    *     remove from the tree.
    */
   deleteWorkspaceContentsNode(workspaceContentsName) {
-    deleteComponentNode(WORKSPACE_CONTENTS_PREFIX, workspaceContentsName);
+    this.deleteComponentNode(WORKSPACE_CONTENTS_PREFIX, workspaceContentsName);
   }
 
   /**
@@ -218,7 +218,7 @@ class NavigationTree {
    *     WorkspaceConfiguration to remove from the tree.
    */
   deleteWorkspaceConfigurationNode(workspaceConfigName) {
-    deleteComponentNode(WORKSPACE_CONFIG_PREFIX, workspaceConfigName);
+    this.deleteComponentNode(WORKSPACE_CONFIG_PREFIX, workspaceConfigName);
   }
 
   /**
@@ -228,7 +228,7 @@ class NavigationTree {
    *     from the tree.
    */
   deleteBlockLibraryNode(blockLibraryName) {
-    deleteComponentNode(LIBRARY_PREFIX, blockLibraryName);
+    this.deleteComponentNode(LIBRARY_PREFIX, blockLibraryName);
   }
 
   /**


### PR DESCRIPTION
Can define blocks. It will update the preview, block definition, and the generator stub.

Currently, testing for these features will not work because it depends on some functions in `ProjectController` and some model classes (`BlockLibrarySet`, `BlockLibrary`, etc.) which are not yet implemented (but will be in upcoming PR's).

**EDIT:** Code will break when testing because I have now removed functions in `ProjectController` that have already been implemented in #118 (to avoid merge conflicts).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/117)
<!-- Reviewable:end -->
