### PR TITLE
Workspace Editor

### DIFF
--- a/src/all_libs_classes_stylesheets.js
+++ b/src/all_libs_classes_stylesheets.js
@@ -44,7 +44,6 @@
   appendScript('src/factory_utils.js');
   appendScript('src/list_element.js');
   appendScript('res/standard_categories.js');
-  appendScript('src/workspacefactory/wfactory_model.js');
   appendScript('res/devtools_toolboxes.js');
   appendScript('src/block_option.js');
   appendScript('src/blocks.js');

--- a/src/controller/app_controller.js
+++ b/src/controller/app_controller.js
@@ -181,25 +181,6 @@ class AppController {
     return 'WORKSPACE_EDITOR';
   }
 
-  // ========================= VIEW-CONTROLLER ==========================
-
-  /**
-   * If given checkbox is checked, enable the given elements.  Otherwise, disable.
-   * @param {boolean} enabled True if enabled, false otherwise.
-   * @param {!Array.<string>} idArray Array of element IDs to enable when
-   *     checkbox is checked.
-   */
-  ifCheckedEnable(enabled, idArray) {
-    /*
-     * TODO: Move in from app_controller.js
-     */
-    // Note: Not implemented because it is in the exporter tab, which will be
-    // deprecated. May implement later if necessary.
-    throw 'Unimplemented: ifCheckedEnable()';
-  }
-
-  // ========================= MODEL-CONTROLLER ==========================
-
   /**
    * Handle Blockly Storage with App Engine.
    */

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -50,24 +50,15 @@ class WorkspaceController {
      */
     this.projectController = projectController;
 
-    /**
-     * Keeps track of what WorkspaceContents is currently being edited.
-     * @type {!WorkspaceContents}
-     */
-    this.currentWorkspaceContents = this.projectController.createWorkspaceContents('WSContents');
-
-    /**
-     * Keeps track of what WorkspaceConfig is currently being edited.
-     * @type {!WorkspaceContents}
-     */
-    this.currentWorkspaceConfig = this.projectController.createWorkspaceConfiguration('WSConfig');
+    // Creates first workspace contents and config to add to project.
+    const wsContents = this.projectController.createWorkspaceContents('WSContents');
+    const wsConfig = this.projectController.createWorkspaceConfiguration('WSConfig');
 
     /**
      * WorkspaceEditorView associated with this instance of WorkspaceController.
      * @type {!WorkspaceEditorView}
      */
-    this.view = new WorkspaceEditorView(
-        this.currentWorkspaceContents, this.currentWorkspaceConfig);
+    this.view = new WorkspaceEditorView(wsContents, wsConfig);
 
     /**
      * True if key events are enabled. False otherwise. Used to enable/disable

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -54,13 +54,13 @@ class WorkspaceController {
      * Keeps track of what WorkspaceContents is currently being edited.
      * @type {!WorkspaceContents}
      */
-    this.currentWorkspaceContents = null;
+    this.currentWorkspaceContents = new WorkspaceContents('WSContents');
 
     /**
      * Keeps track of what WorkspaceConfig is currently being edited.
      * @type {!WorkspaceContents}
      */
-    this.currentWorkspaceConfig = null;
+    this.currentWorkspaceConfig = new WorkspaceConfiguration('WSConfig');
 
     /**
      * WorkspaceEditorView associated with this instance of WorkspaceController.
@@ -81,6 +81,9 @@ class WorkspaceController {
      * @type {!Blockly.Workspace}
      */
     this.hiddenWorkspace = hiddenWorkspace;
+
+    // Initializes view's event listeners/handlers.
+    // this.view.init(this);
   }
 
   /**
@@ -116,7 +119,34 @@ class WorkspaceController {
      * - readOptions_()
      * - generateWorkspaceXml()
      */
-    throw 'Unimplemented: reinjectPreview()';
+    console.warn('Unimplemented: reinjectPreview()');
+  }
+
+  /**
+   * Called every time there is a change to the editor workspace. Called from
+   * a change listener on the editor workspace.
+   * @param {!Event} event The change event which triggered the listener.
+   */
+  onChange(event) {
+    console.log('Change detected!');
+    const isCreateEvent = event.type == Blockly.Events.CREATE;
+    const isMoveEvent = event.type == Blockly.Events.MOVE;
+    const isDeleteEvent = event.type == Blockly.Events.DELETE;
+    const isChangeEvent = event.type == Blockly.Events.CHANGE;
+    const isUiEvent = event.type == Blockly.Events.UI;
+
+    if (isCreateEvent || isDeleteEvent || isChangeEvent) {
+      this.saveStateFromWorkspace();
+      this.updatePreview();
+    }
+  }
+
+  /**
+   * Saves blocks on editor workspace into the WorkspaceContents model.
+   */
+  saveStateFromWorkspace() {
+    const workspaceBlocks = Blockly.Xml.workspaceToDom(this.view.editorWorkspace);
+    this.view.workspaceContents.setXml(workspaceBlocks);
   }
 
   /**

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -110,7 +110,7 @@ class WorkspaceController {
    */
   reinjectPreview() {
     // From wfactory_controller.js:reinjectPreview(tree)
-    this.previewWorkspace.dispose();
+    this.view.previewWorkspace.dispose();
     const injectOptions = this.view.workspaceConfig.options;
     injectOptions['toolbox'] = '<xml></xml>';
 
@@ -125,11 +125,10 @@ class WorkspaceController {
    * @param {!Event} event The change event which triggered the listener.
    */
   onChange(event) {
-    console.log('Change detected!');
     const isCreateEvent = event.type == Blockly.Events.CREATE;
-    const isMoveEvent = event.type == Blockly.Events.MOVE;
     const isDeleteEvent = event.type == Blockly.Events.DELETE;
     const isChangeEvent = event.type == Blockly.Events.CHANGE;
+    const isMoveEvent = event.type == Blockly.Events.MOVE;
     const isUiEvent = event.type == Blockly.Events.UI;
 
     if (isCreateEvent || isDeleteEvent || isChangeEvent) {
@@ -157,7 +156,6 @@ class WorkspaceController {
     this.view.resetConfigs();
     this.generateNewOptions();
     this.updatePreview();
-    throw 'Unimplemented: clear()';
   }
 
   /**
@@ -165,8 +163,10 @@ class WorkspaceController {
    * currently being edited.
    */
   updatePreview() {
-    // TODO: Move in from wfactory_controller.js:updatePreview()
-    throw 'Unimplemented: updatePreview()';
+    // From wfactory_controller.js:updatePreview()
+    this.view.previewWorkspace.clear();
+    Blockly.Xml.domToWorkspace(this.view.workspaceContents.getXml(),
+        this.view.previewWorkspace);
   }
 
   /**

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -333,10 +333,7 @@ class WorkspaceController {
   generateNewOptions() {
     // From wfactory_controller.js:generateNewOptions()
 
-    // TODO: Add popup for workspace config so that preview is updated only when
-    //       creating a new WorkspaceConfig object in completion, or when user
-    //       clicks on an already defined WorkspaceConfig object in list.
-    //       See Design Doc for more info.
+    // TODO (#141): Add popup for workspace config.
 
     this.view.workspaceConfig.setOptions(this.readOptions_());
     this.reinjectPreview();

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -338,7 +338,7 @@ class WorkspaceController {
    */
   readOptions_() {
     // From wfactory_controller.js
-    var optionsObj = Object.create(null);
+    const optionsObj = Object.create(null);
 
     // Add all standard options to the options object.
     // Use parse int to get numbers from value inputs.

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -54,13 +54,13 @@ class WorkspaceController {
      * Keeps track of what WorkspaceContents is currently being edited.
      * @type {!WorkspaceContents}
      */
-    this.currentWorkspaceContents = new WorkspaceContents('WSContents');
+    this.currentWorkspaceContents = this.projectController.createWorkspaceContents('WSContents');
 
     /**
      * Keeps track of what WorkspaceConfig is currently being edited.
      * @type {!WorkspaceContents}
      */
-    this.currentWorkspaceConfig = new WorkspaceConfiguration('WSConfig');
+    this.currentWorkspaceConfig = this.projectController.createWorkspaceConfiguration('WSConfig');
 
     /**
      * WorkspaceEditorView associated with this instance of WorkspaceController.

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -152,9 +152,13 @@ class WorkspaceController {
    */
   clear() {
     // REFACTORED: Moved in (partially) from wfactory_controller.js:clearAll()
-    this.currentWorkspaceContents.setXml('<xml></xml>');
+    // Resets WS Contents
+    this.view.editorWorkspace.clear();
+    this.saveStateFromWorkspace();
+    // Resets WS Configs
     this.view.resetConfigs();
     this.generateNewOptions();
+
     this.updatePreview();
   }
 

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -83,7 +83,7 @@ class WorkspaceController {
     this.hiddenWorkspace = hiddenWorkspace;
 
     // Initializes view's event listeners/handlers.
-    // this.view.init(this);
+    this.view.init(this);
   }
 
   /**
@@ -106,20 +106,17 @@ class WorkspaceController {
    * Used to completely reinject the contents/config preview. Used only
    * when switching from simple flyout to categories, or categories to simple
    * flyout. More expensive than simply updating flyout or toolbox.
-   *
-   * @param {!Element} Tree of XML elements
    * @package
    */
-  reinjectPreview(tree) {
-    /*
-     * TODO: Move in from wfactory_controller.js
-     *       (Also moved into: toolbox_controller.js)
-     *
-     * References:
-     * - readOptions_()
-     * - generateWorkspaceXml()
-     */
-    console.warn('Unimplemented: reinjectPreview()');
+  reinjectPreview() {
+    // From wfactory_controller.js:reinjectPreview(tree)
+    this.previewWorkspace.dispose();
+    const injectOptions = this.view.workspaceConfig.options;
+    injectOptions['toolbox'] = '<xml></xml>';
+
+    this.view.previewWorkspace = Blockly.inject('workspacePreview', injectOptions);
+    Blockly.Xml.domToWorkspace(
+        this.view.workspaceContents.getXml(), this.view.previewWorkspace);
   }
 
   /**
@@ -318,16 +315,9 @@ class WorkspaceController {
    * are present.
    */
   setStandardOptionsAndUpdate() {
-    /*
-     * TODO: Move in from wfactory_controller.js
-     *
-     * References:
-     * - setBaseOptions()
-     * - setCategoryOptions()
-     * - hasElements()
-     * - generateNewOptions()
-     */
-    throw 'Unimplemented: setStandardOptionsAndUpdate()';
+    // From wfactory_controller.js:setStandardOptionsAndUpdate()
+    this.view.resetConfigs();
+    this.generateNewOptions();
   }
 
   /**
@@ -337,21 +327,15 @@ class WorkspaceController {
    * and reinjects the preview workspace.
    */
   generateNewOptions() {
-    /*
-     * TODO: Move in from wfactory_controller.js
-     *
-     * References:
-     * - setOptions()
-     * - readOptions_()
-     * - reinjectPreview()
-     * - generateToolboxXml()
-     */
+    // From wfactory_controller.js:generateNewOptions()
 
     // TODO: Add popup for workspace config so that preview is updated only when
     //       creating a new WorkspaceConfig object in completion, or when user
     //       clicks on an already defined WorkspaceConfig object in list.
     //       See Design Doc for more info.
-    throw 'Unimplemented: generateNewOptions()';
+
+    this.view.workspaceConfig.setOptions(this.readOptions_());
+    this.reinjectPreview();
   }
 
   /**
@@ -361,13 +345,93 @@ class WorkspaceController {
    * @private
    */
   readOptions_() {
-    /*
-     * TODO: Move in from wfactory_controller.js
-     *
-     * References:
-     * - user input (no other relevant DevTools fcn's)
-     */
-    throw 'Unimplemented: readOptions_()';
+    // From wfactory_controller.js
+    var optionsObj = Object.create(null);
+
+    // Add all standard options to the options object.
+    // Use parse int to get numbers from value inputs.
+    var readonly = document.getElementById('option_readOnly_checkbox').checked;
+    if (readonly) {
+      optionsObj['readOnly'] = true;
+    } else {
+      optionsObj['collapse'] =
+          document.getElementById('option_collapse_checkbox').checked;
+      optionsObj['comments'] =
+          document.getElementById('option_comments_checkbox').checked;
+      optionsObj['disable'] =
+          document.getElementById('option_disable_checkbox').checked;
+      if (document.getElementById('option_infiniteBlocks_checkbox').checked) {
+        optionsObj['maxBlocks'] = Infinity;
+      } else {
+        var maxBlocksValue =
+            document.getElementById('option_maxBlocks_number').value;
+        optionsObj['maxBlocks'] = typeof maxBlocksValue == 'string' ?
+            parseInt(maxBlocksValue) : maxBlocksValue;
+      }
+      optionsObj['trashcan'] =
+          document.getElementById('option_trashcan_checkbox').checked;
+      optionsObj['horizontalLayout'] =
+          document.getElementById('option_horizontalLayout_checkbox').checked;
+      optionsObj['toolboxPosition'] =
+          document.getElementById('option_toolboxPosition_checkbox').checked ?
+          'end' : 'start';
+    }
+
+    optionsObj['css'] = document.getElementById('option_css_checkbox').checked;
+    optionsObj['media'] = document.getElementById('option_media_text').value;
+    optionsObj['rtl'] = document.getElementById('option_rtl_checkbox').checked;
+    optionsObj['scrollbars'] =
+        document.getElementById('option_scrollbars_checkbox').checked;
+    optionsObj['sounds'] =
+        document.getElementById('option_sounds_checkbox').checked;
+    optionsObj['oneBasedIndex'] =
+        document.getElementById('option_oneBasedIndex_checkbox').checked;
+
+    // If using a grid, add all grid options.
+    if (document.getElementById('option_grid_checkbox').checked) {
+      var grid = Object.create(null);
+      var spacingValue =
+          document.getElementById('gridOption_spacing_number').value;
+      grid['spacing'] = typeof spacingValue == 'string' ?
+          parseInt(spacingValue) : spacingValue;
+      var lengthValue = document.getElementById('gridOption_length_number').value;
+      grid['length'] = typeof lengthValue == 'string' ?
+          parseInt(lengthValue) : lengthValue;
+      grid['colour'] = document.getElementById('gridOption_colour_text').value;
+      if (!readonly) {
+        grid['snap'] =
+          document.getElementById('gridOption_snap_checkbox').checked;
+      }
+      optionsObj['grid'] = grid;
+    }
+
+    // If using zoom, add all zoom options.
+    if (document.getElementById('option_zoom_checkbox').checked) {
+      var zoom = Object.create(null);
+      zoom['controls'] =
+          document.getElementById('zoomOption_controls_checkbox').checked;
+      zoom['wheel'] =
+          document.getElementById('zoomOption_wheel_checkbox').checked;
+      var startScaleValue =
+          document.getElementById('zoomOption_startScale_number').value;
+      zoom['startScale'] = typeof startScaleValue == 'string' ?
+          parseFloat(startScaleValue) : startScaleValue;
+      var maxScaleValue =
+          document.getElementById('zoomOption_maxScale_number').value;
+      zoom['maxScale'] = typeof maxScaleValue == 'string' ?
+          parseFloat(maxScaleValue) : maxScaleValue;
+      var minScaleValue =
+          document.getElementById('zoomOption_minScale_number').value;
+      zoom['minScale'] = typeof minScaleValue == 'string' ?
+          parseFloat(minScaleValue) : minScaleValue;
+      var scaleSpeedValue =
+          document.getElementById('zoomOption_scaleSpeed_number').value;
+      zoom['scaleSpeed'] = typeof scaleSpeedValue == 'string' ?
+          parseFloat(scaleSpeedValue) : scaleSpeedValue;
+      optionsObj['zoom'] = zoom;
+    }
+
+    return optionsObj;
   }
 
   /**

--- a/src/factory.css
+++ b/src/factory.css
@@ -221,7 +221,7 @@ button, .buttonStyle {
   width: 100%;
 }
 
-#wContentsDiv {
+#wsContentsDiv {
   height: 100%;
   width:100%;
 }
@@ -460,7 +460,7 @@ td.taboff:hover {
 
 /* Toolbox & Workspace Editor Workspace */
 
-#toolbox_section {
+#toolbox_section, #workspace_section {
   height: 85%;
   width: 60%;
 }

--- a/src/factory.css
+++ b/src/factory.css
@@ -453,6 +453,11 @@ td.taboff:hover {
   width: 60%;
 }
 
+#workspace_section {
+  height: 85%;
+  width: 60%;
+}
+
 #previewHelp {
   padding: 10px;
   width: 98%;

--- a/src/factory.css
+++ b/src/factory.css
@@ -221,7 +221,7 @@ button, .buttonStyle {
   width: 100%;
 }
 
-#wsContentsDiv {
+#wContentsDiv {
   height: 100%;
   width:100%;
 }
@@ -448,19 +448,21 @@ td.taboff:hover {
   width: auto;
 }
 
-#toolbox_section {
-  height: 85%;
-  width: 60%;
-}
-
-#workspace_section {
-  height: 85%;
-  width: 60%;
-}
-
 #previewHelp {
   padding: 10px;
   width: 98%;
+}
+
+.disabled {
+  background-color: white;
+  opacity: 0.5;
+}
+
+/* Toolbox & Workspace Editor Workspace */
+
+#toolbox_section {
+  height: 85%;
+  width: 60%;
 }
 
 #createDiv {
@@ -481,11 +483,6 @@ td.taboff:hover {
   border: 5px solid #ddd;
   height: 100%;
   padding-right: 20px;
-}
-
-.disabled {
-  background-color: white;
-  opacity: 0.5;
 }
 
 #toolbox_div {

--- a/src/factory.css
+++ b/src/factory.css
@@ -221,7 +221,7 @@ button, .buttonStyle {
   width: 100%;
 }
 
-#wContentsDiv {
+#wsContentsDiv {
   height: 100%;
   width:100%;
 }

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -1272,3 +1272,25 @@ FactoryUtils.closeModal = function(id) {
   modal.hide();
   $('#modalShadow').hide();
 };
+
+/**
+ * If given checkbox is checked, enable the given elements.  Otherwise, disable.
+ * @param {boolean} enabled True if enabled, false otherwise.
+ * @param {!Array.<string>} idArray Array of element IDs to enable when
+ *     checkbox is checked.
+ */
+FactoryUtils.ifCheckedEnable = function(enabled, idArray) {
+  // From app_controller.js:ifCheckedEnable()
+  for (let id of idArray) {
+    let element = document.getElementById(id);
+    if (enabled) {
+      element.classList.remove('disabled');
+    } else {
+      element.classList.add('disabled');
+    }
+    let fields = element.querySelectorAll('input, textarea, select');
+    for (let field of fields) {
+      field.disabled = !enabled;
+    }
+  }
+};

--- a/src/view/app_view.js
+++ b/src/view/app_view.js
@@ -130,17 +130,6 @@ class AppView {
     this.win.menu = this.mainMenu;
 
     /**
-     * Div ID of currently open modal. Modals are usually dropdown elements.
-     * @type {?string}
-     * @private
-     * Moved in from app_controller.js
-     */
-    // TODO: Separate modal management into each editor (block definition editor,
-    //       toolbox editor, workspace editor) instead of managing/tracking all
-    //       dropdowns in AppView.
-    this.modalName_ = null;
-
-    /**
      * Keeps track of which view is currently active.
      * @type {!BlockEditorView|!ToolboxEditorView|!WorkspaceEditorView}
      */
@@ -348,7 +337,7 @@ class AppView {
    *
    * @param {string} label Name of MenuItem to enable/disable.
    * @param {boolean} enable Whether to enable or disable the MenuItem (true is
-   * to enable).
+   *     to enable).
    */
   enableMenuItem(label, enable) {
     this.menuItems[label].enabled = enable;

--- a/src/view/app_view.js
+++ b/src/view/app_view.js
@@ -71,9 +71,8 @@ class AppView {
      * The workspace view for the session.
      * @type {!WorkspaceEditorView}
      */
-    this.workspaceEditorView = new WorkspaceEditorView(
-        new WorkspaceContents('workspace_contents_name'),
-        new WorkspaceConfiguration('default'));
+    this.workspaceEditorView =
+        this.appController.editorController.workspaceController.view;
 
     // Initializes menu structure. Leaf nodes are actionable MenuItems.
     const menuTree = [

--- a/src/view/workspace_editor_view.js
+++ b/src/view/workspace_editor_view.js
@@ -92,8 +92,7 @@ class WorkspaceEditorView {
           colour: '#ccc',
           snap: true
         },
-        media: 'media/',
-        toolbox: DevToolsToolboxes.toolboxEditor([])
+        media: 'media/'
       });
   }
 
@@ -140,7 +139,7 @@ class WorkspaceEditorView {
    * @package
    */
   init(controller) {
-    console.log('init() called.'); debugger;
+    console.log('init() called.');
     this.editorWorkspace.addChangeListener((event) => {
       debugger;
       console.log('change detected...');
@@ -150,6 +149,7 @@ class WorkspaceEditorView {
       console.log('Aha! A change!');
     });
     console.log('init() finished.');
+    this.initConfigListeners_(controller);
   }
 
   /**
@@ -175,7 +175,9 @@ class WorkspaceEditorView {
      * TODO: Move in from wfactory_init.js:addWorkspaceFactoryEventListeners_()
      *       (Also moved into toolbox_editor_view.js)
      */
-    console.warn('Unimplemented: initEventListeners_()');
+    $('#button_standardOptions').click(() => {
+      controller.setStandardOptionsAndUpdate();
+    });
   }
 
   /**
@@ -183,21 +185,96 @@ class WorkspaceEditorView {
    * WorkspaceConfig objects.
    * @private
    */
-  initConfigListeners_() {
+  initConfigListeners_(controller) {
     /*
      * TODO: Move in from wfactory_init.js:addWorkspaceFactoryOptionsListeners_()
      */
-    console.warn('Unimplemented: initConfigListeners_()');
+    // Checking the grid checkbox displays grid options.
+    document.getElementById('option_grid_checkbox').addEventListener('change',
+        function(e) {
+          document.getElementById('grid_options').style.display =
+              document.getElementById('option_grid_checkbox').checked ?
+              'block' : 'none';
+        });
+
+    // Checking the zoom checkbox displays zoom options.
+    document.getElementById('option_zoom_checkbox').addEventListener('change',
+        function(e) {
+          document.getElementById('zoom_options').style.display =
+              document.getElementById('option_zoom_checkbox').checked ?
+              'block' : 'none';
+        });
+
+    // Checking the readonly checkbox enables/disables other options.
+    document.getElementById('option_readOnly_checkbox').addEventListener('change',
+      function(e) {
+        const checkbox = document.getElementById('option_readOnly_checkbox');
+        FactoryUtils.ifCheckedEnable(!checkbox.checked,
+            ['readonly1', 'readonly2']);
+      });
+
+      document.getElementById('option_infiniteBlocks_checkbox').addEventListener('change',
+      function(e) {
+        document.getElementById('maxBlockNumber_option').style.display =
+            document.getElementById('option_infiniteBlocks_checkbox').checked ?
+              'none' : 'block';
+      });
+
+    // Generate new options every time an options input is updated.
+    const div = document.getElementById('workspace_options');
+    const options = div.getElementsByTagName('input');
+    for (let option of options) {
+      option.addEventListener('change', () => {
+        controller.generateNewOptions();
+      });
+    }
   }
 
   /**
-   * Resets WorkspaceConfig checkboxes to default settings.
+   * Resets WorkspaceConfig checkboxes to default settings. Does not edit the
+   * model-side.
    */
   resetConfigs() {
-    /*
-     * TODO: Move in from wfactory_view.js:setBaseOptions()
-     */
-    console.warn('Unimplemented: resetConfigs()');
+    // From wfactory_view.js:setBaseOptions()
+    // Readonly mode.
+    document.getElementById('option_readOnly_checkbox').checked = false;
+    FactoryUtils.ifCheckedEnable(true, ['readonly1', 'readonly2']);
+
+    // Set basic options.
+    document.getElementById('option_css_checkbox').checked = true;
+    document.getElementById('option_maxBlocks_number').value = 100;
+    document.getElementById('option_media_text').value =
+        'https://blockly-demo.appspot.com/static/media/';
+    document.getElementById('option_rtl_checkbox').checked = false;
+    document.getElementById('option_sounds_checkbox').checked = true;
+    document.getElementById('option_oneBasedIndex_checkbox').checked = true;
+    document.getElementById('option_horizontalLayout_checkbox').checked = false;
+    document.getElementById('option_toolboxPosition_checkbox').checked = false;
+
+    // Check infinite blocks and hide suboption.
+    document.getElementById('option_infiniteBlocks_checkbox').checked = true;
+    document.getElementById('maxBlockNumber_option').style.display =
+        'none';
+
+    // Uncheck grid and zoom options and hide suboptions.
+    document.getElementById('option_grid_checkbox').checked = false;
+    document.getElementById('grid_options').style.display = 'none';
+    document.getElementById('option_zoom_checkbox').checked = false;
+    document.getElementById('zoom_options').style.display = 'none';
+
+    // Set grid options.
+    document.getElementById('gridOption_spacing_number').value = 20;
+    document.getElementById('gridOption_length_number').value = 1;
+    document.getElementById('gridOption_colour_text').value = '#888';
+    document.getElementById('gridOption_snap_checkbox').checked = false;
+
+    // Set zoom options.
+    document.getElementById('zoomOption_controls_checkbox').checked = true;
+    document.getElementById('zoomOption_wheel_checkbox').checked = true;
+    document.getElementById('zoomOption_startScale_number').value = 1.0;
+    document.getElementById('zoomOption_maxScale_number').value = 3;
+    document.getElementById('zoomOption_minScale_number').value = 0.3;
+    document.getElementById('zoomOption_scaleSpeed_number').value = 1.2;
   }
 
   /**
@@ -264,7 +341,7 @@ WorkspaceEditorView.html = `
     <h3>Edit Workspace elements</h3>
     <p id="editHelpText">Drag blocks into the workspace to configure your custom workspace.</p>
   </div>
-  <section id="toolbox_section">
+  <section id="workspace_section">
     <div id="wsContentsDiv"></div>
   </section>
 

--- a/src/view/workspace_editor_view.js
+++ b/src/view/workspace_editor_view.js
@@ -68,7 +68,7 @@ class WorkspaceEditorView {
      * Blockly workspace where users define a group of WorkspaceContents.
      * @type {!Blockly.Workspace}
      */
-    this.editorWorkspace = Blockly.inject('wContentsDiv',
+    this.editorWorkspace = Blockly.inject('wsContentsDiv',
       {
         grid: {
           spacing: 25,
@@ -93,7 +93,7 @@ class WorkspaceEditorView {
           snap: true
         },
         media: 'media/',
-        toolbox: '<xml></xml>'
+        toolbox: DevToolsToolboxes.toolboxEditor([])
       });
   }
 
@@ -134,6 +134,25 @@ class WorkspaceEditorView {
   }
 
   /**
+   * Initializes event handlers and listeners for the workspace editor.
+   * @param {!WorkspaceController} controller WorkspaceController that makes
+   *     changes to editor based upon user interaction with application.
+   * @package
+   */
+  init(controller) {
+    console.log('init() called.'); debugger;
+    this.editorWorkspace.addChangeListener((event) => {
+      debugger;
+      console.log('change detected...');
+      controller.onChange(event);
+    });
+    this.previewWorkspace.addChangeListener((event) => {
+      console.log('Aha! A change!');
+    });
+    console.log('init() finished.');
+  }
+
+  /**
    * Assign click handlers for Workspace editor.
    * @private
    */
@@ -147,9 +166,11 @@ class WorkspaceEditorView {
 
   /**
    * Add event listeners for Workspace editor.
+   * @param {!WorkspaceController} controller WorkspaceController that manages
+   *     workspace resource elements on user input.
    * @private
    */
-  initEventListeners_() {
+  initEventListeners_(controller) {
     /*
      * TODO: Move in from wfactory_init.js:addWorkspaceFactoryEventListeners_()
      *       (Also moved into toolbox_editor_view.js)
@@ -241,10 +262,10 @@ WorkspaceEditorView.html = `
 <section id="createDiv">
   <div id="createHeader">
     <h3>Edit Workspace elements</h3>
-    <p id="editHelpText">Drag blocks into the workspace to configure the toolbox in your custom workspace.</p>
+    <p id="editHelpText">Drag blocks into the workspace to configure your custom workspace.</p>
   </div>
   <section id="toolbox_section">
-    <div id="wContentsDiv"></div>
+    <div id="wsContentsDiv"></div>
   </section>
 
   <button id="button_addShadow" style="display: none">Make Shadow</button>

--- a/src/view/workspace_editor_view.js
+++ b/src/view/workspace_editor_view.js
@@ -139,17 +139,15 @@ class WorkspaceEditorView {
    * @package
    */
   init(controller) {
-    console.log('init() called.');
     this.editorWorkspace.addChangeListener((event) => {
-      debugger;
-      console.log('change detected...');
+      Blockly.Events.disable();
       controller.onChange(event);
+      Blockly.Events.enable();
     });
-    this.previewWorkspace.addChangeListener((event) => {
-      console.log('Aha! A change!');
-    });
-    console.log('init() finished.');
     this.initConfigListeners_(controller);
+    this.initEventListeners_(controller);
+    this.resetConfigs();
+    controller.generateNewOptions();
   }
 
   /**
@@ -171,10 +169,7 @@ class WorkspaceEditorView {
    * @private
    */
   initEventListeners_(controller) {
-    /*
-     * TODO: Move in from wfactory_init.js:addWorkspaceFactoryEventListeners_()
-     *       (Also moved into toolbox_editor_view.js)
-     */
+    // From wfactory_init.js:addWorkspaceFactoryEventListeners_()
     $('#button_standardOptions').click(() => {
       controller.setStandardOptionsAndUpdate();
     });
@@ -400,8 +395,8 @@ WorkspaceEditorView.html = `
 <aside id="previewDiv">
   <div id="previewBorder">
     <div id="previewHelp">
-      <h3>Preview</h3>
-      <p>This is what your custom workspace will look like.</p>
+      <h3>Workspace Preview</h3>
+      <p>This is what your custom workspace will look like without your toolbox.</p>
     </div>
     <div id="workspacePreview" class="content"></div>
   </div>

--- a/src/view/workspace_editor_view.js
+++ b/src/view/workspace_editor_view.js
@@ -145,33 +145,31 @@ class WorkspaceEditorView {
       Blockly.Events.enable();
     });
     this.initConfigListeners_(controller);
-    this.initEventListeners_(controller);
+    this.initClickHandlers_(controller);
     this.resetConfigs();
     controller.generateNewOptions();
   }
 
   /**
    * Assign click handlers for Workspace editor.
-   * @private
-   */
-  initClickHandlers_() {
-    /*
-     * TODO: Move in from wfactory_init.js:assignWorkspaceFactoryClickHandlers_()
-     *       (Also moved into toolbox_editor_view.js)
-     */
-     console.warn('Unimplemented: initClickHandlers_()');
-  }
-
-  /**
-   * Add event listeners for Workspace editor.
    * @param {!WorkspaceController} controller WorkspaceController that manages
    *     workspace resource elements on user input.
    * @private
    */
-  initEventListeners_(controller) {
-    // From wfactory_init.js:addWorkspaceFactoryEventListeners_()
+  initClickHandlers_(controller) {
+    // From wfactory_init.js:assignWorkspaceFactoryClickHandlers_()
     $('#button_standardOptions').click(() => {
       controller.setStandardOptionsAndUpdate();
+    });
+    $('#button_optionsHelp').click(() => {
+      open('https://developers.google.com/blockly/guides/get-started/web#configuration');
+    });
+    $('#button_clearWorkspace').click(() => {
+      this.editorWorkspace.clear();
+      if (confirm('Are you sure you would like to clear your workspace contents' +
+          ' and configurations?')) {
+        controller.clear();
+      }
     });
   }
 
@@ -325,7 +323,7 @@ WorkspaceEditorView.html = `
       </div>
     </div>
 
-    <button id="button_clear">Clear</button>
+    <button id="button_clearWorkspace">Clear</button>
 
     <span id="saved_message"></span>
   </p>

--- a/src/view/workspace_editor_view.js
+++ b/src/view/workspace_editor_view.js
@@ -176,6 +176,8 @@ class WorkspaceEditorView {
   /**
    * Add listeners for Workspace editor input elements. Used for creating/editing
    * WorkspaceConfig objects.
+   * @param {!WorkspaceController} controller WorkspaceController that manages
+   *     workspace resource elements on user input.
    * @private
    */
   initConfigListeners_(controller) {


### PR DESCRIPTION
Can now: 
 - Create a set of blocks to pre-load onto workspace.
 - Configure options for `Blockly.inject()`.
 - Reset WorkspaceConfiguration to default values via "Reset to Default" button.
 - Clear workspace editor (via "clear" button).

Cannot:
 - Import
 - Load to edit
 - Export

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/138)
<!-- Reviewable:end -->
