### PR TITLE
Toolbox Editor (4/4): Shadow Blocks

### DIFF
--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -513,7 +513,6 @@ class ToolboxController {
     // user loads blocks into workspace directly without calling updatePreview.
     if (isMoveEvent || isDeleteEvent || isChangeEvent || isUiEvent) {
       this.saveStateFromWorkspace();
-      this.view.toolbox.setXml(this.generateToolboxXml());
       this.updatePreview();
     }
 

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -559,14 +559,27 @@ class ToolboxController {
     }
 
     // Check if shadow block.
-    const isShadow = this.isUserGenShadowBlock(selected.id);
+    const isShadow = this.isUserGenShadowBlock(selected.id) ||
+        $(selected.svgGroup_).hasClass('shadowBlock');
     // Check if valid shadow block position.
     const isValid = selected != null && selected.getSurroundParent() != null &&
         !this.isUserGenShadowBlock(selected.getSurroundParent().id);
+    // Check if block has variables (variable blocks cannot be shadow blocks).
+    const hasVar = !FactoryUtils.hasVariableField(selected);
     this.view.enableShadowButtons(isShadow, isValid);
 
+    console.log('isShadow: ' + isShadow);
+    console.log('isValid: ' + isValid);
+    console.log('hasVar: ' + hasVar);
+    console.log('\n');
+
     if (isShadow && !isValid) {
-      selected.setWarningText('');
+      selected.setWarningText('Shadow blocks must be nested inside\n'
+          + 'other shadow blocks or regular blocks.\nRegular blocks '
+          + 'cannot be nested inside\nshadow blocks.');
+    } else if (isShadow && hasVar) {
+      selected.setWarningText('Shadow blocks must be nested inside other'
+          + ' blocks.');
     } else {
       selected.setWarningText(null);
     }
@@ -656,7 +669,7 @@ class ToolboxController {
       // Warn if a shadow block is invalid only if not replacing
       // warning for variables.
       selectedBlock.setWarningText('Shadow blocks must be nested inside other'
-          + ' blocks.')
+          + ' blocks.');
     }
   }
 
@@ -672,8 +685,8 @@ class ToolboxController {
 
     // Let the user create a Variables or Functions category if they use
     // blocks from either category.
-    const newBaseBlock = this.view.editorWorkspace.getBlockById(blockId);
-    this.warnForMissingCategory_(newBaseBlock.getDescendants());
+    const newBlock = this.view.editorWorkspace.getBlockById(blockId);
+    this.warnForMissingCategory_(newBlock.getDescendants());
   }
 
   /**

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -556,7 +556,7 @@ class ToolboxController {
    * them (which would be impossible with actual shadow blocks). Updates the
    * preview when done.
    */
-  addShadow() {
+  setSelectedAsShadowBlock() {
     // From wfactory_controller.js:addShadow()
     // No block selected to make a shadow block.
     if (!this.view.selectedBlock) {
@@ -584,7 +584,7 @@ class ToolboxController {
    * block from list of shadow blocks and then reloads workspace. Updates the
    * preview when done.
    */
-  removeShadow() {
+  unsetSelectedAsShadowBlock() {
     // From wfactory_controller.js
     if (!this.view.selectedBlock) {
       return;

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -522,8 +522,19 @@ class ToolboxController {
     // surrounding parent, meaning it is nested in another block (blocks that
     // are not nested in parents cannot be shadow blocks).
     if (isMoveEvent || isUiEvent) {
+      Blockly.Events.disable();
       const selected = this.view.editorWorkspace.getBlockById(e.blockId);
       this.view.selectedBlock = selected;
+
+      if (selected &&
+          selected.getSurroundParent() &&
+          $(selected.getSurroundParent().svgGroup_).hasClass('shadowBlock')) {
+        console.log(selected.getSurroundParent());
+        console.log('selected:' );
+        console.log(selected);
+        selected.setWarningText('Regular blocks cannot be children of shadow\n'
+            + 'blocks.');
+      }
       // const project = this.projectController.getProject();
 
       // // Displays shadow buttons only when user clicks on a block.
@@ -534,6 +545,9 @@ class ToolboxController {
       //     !this.isUserGenShadowBlock(selected.getSurroundParent().id);
       // this.allowShadow_(isPotentialShadow, selected);
       this.showShadowButtons_(selected);
+      Blockly.Events.enable();
+    } else {
+      this.view.selectedBlock = null;
     }
 
     if (isCreateEvent) {
@@ -564,7 +578,8 @@ class ToolboxController {
         $(selected.svgGroup_).hasClass('shadowBlock');
     // Check if valid shadow block position.
     const isValid = selected != null && selected.getSurroundParent() != null &&
-        !this.isUserGenShadowBlock(selected.getSurroundParent().id);
+        !this.isUserGenShadowBlock(selected.getSurroundParent().id) &&
+        selected.getChildren().length == 0;
     // Check if block has variables (variable blocks cannot be shadow blocks).
     const hasVar = FactoryUtils.hasVariableField(selected);
     this.view.enableShadowButtons(isShadow, isValid);

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -602,17 +602,6 @@ class ToolboxController {
   }
 
   /**
-   * Shows buttons to create/remove shadow blocks only when a block is selected.
-   * @private
-   */
-  showShadowButtons_() {
-    // Show shadow button if a block is selected.
-    const show = this.view.selectedBlock ? true : false;
-    this.view.displayAddShadow(show);
-    this.view.displayRemoveShadow(show);
-  }
-
-  /**
    * Checks the currently selected block if it is breaking any shadow block rules.
    * Sets warning text to user if it is breaking a rule, and removes warning
    * text if it not.

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -583,7 +583,7 @@ class ToolboxController {
   /**
    * If the currently selected block is a user-generated shadow block, this
    * function makes it a normal block again, removing it from the list of
-   * shadow blocks and loading the workspace again. Updates the preview again.
+   * shadow blocks and loading the workspace again. Updates the preview.
    */
   removeShadow() {
     // From wfactory_controller.js
@@ -602,12 +602,12 @@ class ToolboxController {
   }
 
   /**
-   * Checks the currently selected block if it is breaking any shadow block rules.
-   * Sets warning text to user if it is breaking a rule, and removes warning
-   * text if it not.
-   * Shadow blocks must be nested within another block, and cannot have any
+   * Checks currently selected block if it is breaking any shadow block rules.
+   * Sets warning text to user if it breaks a rule, and removes warning
+   * text if not.
+   * Shadow blocks must be nested within another block and cannot have any
    * non-shadow blocks as children.
-   * @recursive Checks children and connected blocks for their status as well.
+   * @recursive Checks connected blocks for their shadow block status.
    */
   checkShadowStatus() {
     const selected = this.view.selectedBlock;
@@ -750,7 +750,7 @@ Do you want to add a ${categoryName} category to your custom toolbox?`;
    */
   saveStateFromWorkspace() {
     this.view.toolbox.getSelected().saveFromWorkspace(this.view.editorWorkspace);
-    this.view.toolbox.setXml(this.generateToolboxXml()); // celine
+    this.view.toolbox.setXml(this.generateToolboxXml());
   }
 
   /**

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -580,9 +580,9 @@ class ToolboxController {
   }
 
   /**
-   * If the currently selected block is a user-generated shadow block, this
-   * function makes it a normal block again, removing it from the list of
-   * shadow blocks and loading the workspace again. Updates the preview.
+   * Makes user-generated shadow block back to a normal block again. Removes
+   * block from list of shadow blocks and then reloads workspace. Updates the
+   * preview when done.
    */
   removeShadow() {
     // From wfactory_controller.js

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -523,6 +523,7 @@ class ToolboxController {
     // are not nested in parents cannot be shadow blocks).
     if (isMoveEvent || isUiEvent) {
       const selected = this.view.editorWorkspace.getBlockById(e.blockId);
+      this.view.selectedBlock = selected;
       // const project = this.projectController.getProject();
 
       // // Displays shadow buttons only when user clicks on a block.
@@ -565,7 +566,7 @@ class ToolboxController {
     const isValid = selected != null && selected.getSurroundParent() != null &&
         !this.isUserGenShadowBlock(selected.getSurroundParent().id);
     // Check if block has variables (variable blocks cannot be shadow blocks).
-    const hasVar = !FactoryUtils.hasVariableField(selected);
+    const hasVar = FactoryUtils.hasVariableField(selected);
     this.view.enableShadowButtons(isShadow, isValid);
 
     console.log('isShadow: ' + isShadow);

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -926,7 +926,11 @@ FactoryUtils.hasVariableField = function(block) {
   if (!block) {
     return false;
   }
-  return block.getVars().length > 0;
+  const vars = block.getVars();
+  if (vars.length > 0) {
+    console.log(block.getVars());
+  }
+  return vars.length > 0;
 };
 
 /**

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -934,6 +934,21 @@ FactoryUtils.hasVariableField = function(block) {
 };
 
 /**
+ * Returns array of shadow blocks from a list of blocks.
+ * @param {!Array.<!Blockly.Block>} blockList List of blocks.
+ * @return {!Array.<!Blockly.Block>} List of shadow blocks from given list.
+ */
+FactoryUtils.getShadowBlocks = function(blockList) {
+  let shadowBlocks = [];
+  for (let block of blockList) {
+    if ($(block.svgGroup_).hasClass('shadowBlock')) {
+      shadowBlocks.push(block);
+    }
+  }
+  return shadowBlocks;
+};
+
+/**
  * Checks if a block is a procedures block. If procedures block names are
  * ever updated or expanded, this function should be updated as well (no
  * other known markers for procedure blocks beyond name).

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -926,11 +926,7 @@ FactoryUtils.hasVariableField = function(block) {
   if (!block) {
     return false;
   }
-  const vars = block.getVars();
-  if (vars.length > 0) {
-    console.log(block.getVars());
-  }
-  return vars.length > 0;
+  return block.getVars().length > 0;
 };
 
 /**

--- a/src/model/toolbox.js
+++ b/src/model/toolbox.js
@@ -324,13 +324,13 @@ class Toolbox extends Resource {
    * @param {string} blockId The unique ID of block to be removed.
    */
   removeShadowBlock(blockId) {
-    /*
-     * TODO: Move in from wfactory_model.js
-     *
-     * References:
-     * - this.shadowBlocks
-     */
-    throw 'Unimplemented: removeShadowBlock()';
+    // From wfactory_model.js:removeShadowBlock(blockId)
+    for (let i = 0; i < this.shadowBlocks.length; i++) {
+      if (this.shadowBlocks[i] == blockId) {
+        this.shadowBlocks.splice(i, 1);
+        return;
+      }
+    }
   }
 
   /**

--- a/src/model/toolbox.js
+++ b/src/model/toolbox.js
@@ -313,7 +313,7 @@ class Toolbox extends Resource {
    */
   addShadowBlock(blockId) {
     // Moved in from wfactory_model.js
-    if (this.shadowBlocks.indexOf(blockId) != -1) {
+    if (this.shadowBlocks.indexOf(blockId) == -1) {
       this.shadowBlocks.push(blockId);
     }
   }

--- a/src/view/toolbox_editor_view.js
+++ b/src/view/toolbox_editor_view.js
@@ -301,12 +301,12 @@ class ToolboxEditorView {
 
     // Listener for adding a shadow block.
     this.addShadowButton.addEventListener('click', () => {
-      controller.addShadow();
+      controller.setSelectedAsShadowBlock();
     });
 
     // Listener for removing a shadow block.
     this.removeShadowButton.addEventListener('click', () => {
-      controller.removeShadow();
+      controller.unsetSelectedAsShadowBlock();
     });
   }
 

--- a/src/view/toolbox_editor_view.js
+++ b/src/view/toolbox_editor_view.js
@@ -641,20 +641,20 @@ class ToolboxEditorView {
   enableShadowButtons(isShadow, isValid) {
     if (isShadow && isValid) {
       // Is a shadow block that is in a valid shadow block position.
-      addButton.disabled = true;
-      removeButton.disabled = false;
+      this.addShadowButton.disabled = true;
+      this.removeShadowButton.disabled = false;
     } else if (isShadow && !isValid) {
       // Is a shadow block that is no longer in a valid shadow block position.
-      addButton.disabled = true;
-      removeButton.disabled = false;
+      this.addShadowButton.disabled = true;
+      this.removeShadowButton.disabled = false;
     } else if (!isShadow && isValid) {
       // Is not a shadow block but can be a valid shadow block.
-      addButton.disabled = false;
-      removeButton.disabled = true;
+      this.addShadowButton.disabled = false;
+      this.removeShadowButton.disabled = true;
     } else {
       // Is not a shadow block and is not in a valid shadow block position.
-      addButton.disabled = true;
-      removeButton.disabled = true;
+      this.addShadowButton.disabled = true;
+      this.removeShadowButton.disabled = true;
     }
   }
 }
@@ -749,7 +749,7 @@ ToolboxEditorView.html = `
 
   </aside>
 
-  <button id="button_addShadow" style="display: none">Make Shadow</button>
+  <button id="button_addShadow" style="display: none">Make Shadow</button><br>
   <button id="button_removeShadow" style="display: none">Remove Shadow</button>
 
 </section>

--- a/src/view/toolbox_editor_view.js
+++ b/src/view/toolbox_editor_view.js
@@ -321,6 +321,26 @@ class ToolboxEditorView {
   }
 
   /**
+   * Shows and enables shadow buttons.
+   * @param {boolean} ifAdd Whether to show the add button. Shows remove button
+   *     if false.
+   * @param {boolean} ifEnable Whether to enable the add or remove button that
+   *     is shown.
+   * @param {boolean=} opt_disableAll Whether to hide both buttons entirely.
+   */
+  showAndEnableShadow(ifAdd, ifEnable, opt_disableAll) {
+    if (opt_disableAll) {
+      this.displayAddShadow(false);
+      this.displayRemoveShadow(false);
+      return;
+    }
+    this.displayAddShadow(ifAdd);
+    this.displayRemoveShadow(!ifAdd);
+    const button = ifAdd ? this.addShadowButton : this.removeShadowButton;
+    button.disabled = ifEnable ? false : true;
+  }
+
+  /**
    * Display or hide the add shadow button.
    * @param {boolean} show True if the add shadow button should be shown, false
    *     otherwise.
@@ -659,20 +679,16 @@ class ToolboxEditorView {
   enableShadowButtons(isShadow, isValid) {
     if (isShadow && isValid) {
       // Is a shadow block that is in a valid shadow block position.
-      this.addShadowButton.disabled = true;
-      this.removeShadowButton.disabled = false;
+      this.showAndEnableShadow(false, true);
     } else if (isShadow && !isValid) {
       // Is a shadow block that is no longer in a valid shadow block position.
-      this.addShadowButton.disabled = true;
-      this.removeShadowButton.disabled = false;
+      this.showAndEnableShadow(false, true);
     } else if (!isShadow && isValid) {
       // Is not a shadow block but can be a valid shadow block.
-      this.addShadowButton.disabled = false;
-      this.removeShadowButton.disabled = true;
+      this.showAndEnableShadow(true, true);
     } else {
       // Is not a shadow block and is not in a valid shadow block position.
-      this.addShadowButton.disabled = true;
-      this.removeShadowButton.disabled = true;
+      this.showAndEnableShadow(true, false);
     }
   }
 }

--- a/src/view/toolbox_editor_view.js
+++ b/src/view/toolbox_editor_view.js
@@ -628,6 +628,35 @@ class ToolboxEditorView {
     // REFACTOR: Moved in from wfactory_view.js
     Blockly.utils.removeClass(block.svgGroup_, 'shadowBlock');
   }
+
+  /**
+   * Enables or disables the add/remove shadow block buttons depending on whether
+   * the selected block (1) is already marked as a shadow block, and (2) is in
+   * a valid shadow block position.
+   * @param {boolean} isShadow Whether the selected block is already marked as
+   *     a shadow block.
+   * @param {boolean} isValid Whether the selected block is in a valid shadow
+   *     block position.
+   */
+  enableShadowButtons(isShadow, isValid) {
+    if (isShadow && isValid) {
+      // Is a shadow block that is in a valid shadow block position.
+      addButton.disabled = true;
+      removeButton.disabled = false;
+    } else if (isShadow && !isValid) {
+      // Is a shadow block that is no longer in a valid shadow block position.
+      addButton.disabled = true;
+      removeButton.disabled = false;
+    } else if (!isShadow && isValid) {
+      // Is not a shadow block but can be a valid shadow block.
+      addButton.disabled = false;
+      removeButton.disabled = true;
+    } else {
+      // Is not a shadow block and is not in a valid shadow block position.
+      addButton.disabled = true;
+      removeButton.disabled = true;
+    }
+  }
 }
 
 /**

--- a/src/view/toolbox_editor_view.js
+++ b/src/view/toolbox_editor_view.js
@@ -45,6 +45,8 @@ class ToolboxEditorView {
      */
     this.toolbox = toolbox;
 
+    this.selectedBlock = null;
+
     /**
      * JQuery container of toolbox editor view.
      * @type {!JQuery}
@@ -289,6 +291,19 @@ class ToolboxEditorView {
       controller.changeCategoryName();
       FactoryUtils.closeModal(this.openModal_);
       this.openModal_ = null;
+    });
+
+    // Listener for adding a shadow block.
+    this.addShadowButton.addEventListener('click', () => {
+      if (this.selectedBlock) {
+        this.markShadowBlock(this.selectedBlock);
+        this.toolbox.shadowBlocks.push(this.selectedBlock.type);
+      }
+    });
+
+    // Listener for removing a shadow block.
+    this.removeShadowButton.addEventListener('click', () => {
+      //
     });
   }
 

--- a/src/view/toolbox_editor_view.js
+++ b/src/view/toolbox_editor_view.js
@@ -297,13 +297,18 @@ class ToolboxEditorView {
     this.addShadowButton.addEventListener('click', () => {
       if (this.selectedBlock) {
         this.markShadowBlock(this.selectedBlock);
-        this.toolbox.shadowBlocks.push(this.selectedBlock.type);
+        this.toolbox.addShadowBlock(this.selectedBlock.id);
+        this.enableShadowButtons(true, true);
       }
     });
 
     // Listener for removing a shadow block.
     this.removeShadowButton.addEventListener('click', () => {
-      //
+      if (this.selectedBlock) {
+        this.unmarkShadowBlock(this.selectedBlock);
+        this.toolbox.removeShadowBlock(this.selectedBlock.id);
+        this.enableShadowButtons(false, true);
+      }
     });
   }
 

--- a/src/view/toolbox_editor_view.js
+++ b/src/view/toolbox_editor_view.js
@@ -321,46 +321,6 @@ class ToolboxEditorView {
   }
 
   /**
-   * Shows and enables shadow buttons.
-   * @param {boolean} ifAdd Whether to show the add button. Shows remove button
-   *     if false.
-   * @param {boolean} ifEnable Whether to enable the add or remove button that
-   *     is shown.
-   * @param {boolean=} opt_disableAll Whether to hide both buttons entirely.
-   */
-  showAndEnableShadow(ifAdd, ifEnable, opt_disableAll) {
-    if (opt_disableAll) {
-      this.displayAddShadow(false);
-      this.displayRemoveShadow(false);
-      return;
-    }
-    this.displayAddShadow(ifAdd);
-    this.displayRemoveShadow(!ifAdd);
-    const button = ifAdd ? this.addShadowButton : this.removeShadowButton;
-    button.disabled = ifEnable ? false : true;
-  }
-
-  /**
-   * Display or hide the add shadow button.
-   * @param {boolean} show True if the add shadow button should be shown, false
-   *     otherwise.
-   */
-  displayAddShadow(show) {
-    // REFACTOR: Moved in from wfactory_init.js:displayAddShadow_(show)
-    this.addShadowButton.style.display = show ? 'inline-block' : 'none';
-  }
-
-  /**
-   * Display or hide the remove shadow button.
-   * @param {boolean} show True if the remove shadow button should be shown, false
-   *     otherwise.
-   */
-  displayRemoveShadow(show) {
-    // TODO: Move in from wfactory_model.js:displayRemoveShadow_(show)
-    this.removeShadowButton.style.display = show ? 'inline-block' : 'none';
-  }
-
-  /**
    * Updates the toolbox used in the toolbox editor workspace.
    * @param {!string} toolbox String representation of toolbox XML to display.
    */
@@ -677,11 +637,8 @@ class ToolboxEditorView {
    *     block position.
    */
   enableShadowButtons(isShadow, isValid) {
-    if (isShadow && isValid) {
-      // Is a shadow block that is in a valid shadow block position.
-      this.showAndEnableShadow(false, true);
-    } else if (isShadow && !isValid) {
-      // Is a shadow block that is no longer in a valid shadow block position.
+    if (isShadow) {
+      // Is a shadow block
       this.showAndEnableShadow(false, true);
     } else if (!isShadow && isValid) {
       // Is not a shadow block but can be a valid shadow block.
@@ -690,6 +647,46 @@ class ToolboxEditorView {
       // Is not a shadow block and is not in a valid shadow block position.
       this.showAndEnableShadow(true, false);
     }
+  }
+
+  /**
+   * Shows and enables shadow buttons.
+   * @param {boolean} ifAdd Whether to show the add button. Shows remove button
+   *     if false.
+   * @param {boolean} ifEnable Whether to enable the add or remove button that
+   *     is shown.
+   * @param {boolean=} opt_disableAll Whether to hide both buttons entirely.
+   */
+  showAndEnableShadow(ifAdd, ifEnable, opt_disableAll) {
+    if (opt_disableAll) {
+      this.displayAddShadow(false);
+      this.displayRemoveShadow(false);
+      return;
+    }
+    this.displayAddShadow(ifAdd);
+    this.displayRemoveShadow(!ifAdd);
+    const button = ifAdd ? this.addShadowButton : this.removeShadowButton;
+    button.disabled = ifEnable ? false : true;
+  }
+
+  /**
+   * Display or hide the add shadow button.
+   * @param {boolean} show True if the add shadow button should be shown, false
+   *     otherwise.
+   */
+  displayAddShadow(show) {
+    // REFACTOR: Moved in from wfactory_init.js:displayAddShadow_(show)
+    this.addShadowButton.style.display = show ? 'inline-block' : 'none';
+  }
+
+  /**
+   * Display or hide the remove shadow button.
+   * @param {boolean} show True if the remove shadow button should be shown, false
+   *     otherwise.
+   */
+  displayRemoveShadow(show) {
+    // TODO: Move in from wfactory_model.js:displayRemoveShadow_(show)
+    this.removeShadowButton.style.display = show ? 'inline-block' : 'none';
   }
 }
 

--- a/src/view/toolbox_editor_view.js
+++ b/src/view/toolbox_editor_view.js
@@ -45,6 +45,12 @@ class ToolboxEditorView {
      */
     this.toolbox = toolbox;
 
+    /**
+     * Keeps track of currently selected block in the editor workspace. Used for
+     * checking the shadow block status of selected blocks and its descendants/
+     * connected blocks. Null if no block is selected.
+     * @type {?Blockly.Block}
+     */
     this.selectedBlock = null;
 
     /**
@@ -295,20 +301,12 @@ class ToolboxEditorView {
 
     // Listener for adding a shadow block.
     this.addShadowButton.addEventListener('click', () => {
-      if (this.selectedBlock) {
-        this.markShadowBlock(this.selectedBlock);
-        this.toolbox.addShadowBlock(this.selectedBlock.id);
-        this.enableShadowButtons(true, true);
-      }
+      controller.addShadow();
     });
 
     // Listener for removing a shadow block.
     this.removeShadowButton.addEventListener('click', () => {
-      if (this.selectedBlock) {
-        this.unmarkShadowBlock(this.selectedBlock);
-        this.toolbox.removeShadowBlock(this.selectedBlock.id);
-        this.enableShadowButtons(false, true);
-      }
+      controller.removeShadow();
     });
   }
 


### PR DESCRIPTION
Can now add/remove shadow blocks in toolbox editor. Accounts for most edge cases in enabling/disabling "add/remove shadow block" button, as well as warning text appearing/disappearing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/146)
<!-- Reviewable:end -->
