### PR TITLE
getJson now getTreeJson

### DIFF
--- a/src/model/block_definition.js
+++ b/src/model/block_definition.js
@@ -60,10 +60,10 @@ class BlockDefinition extends Resource {
   }
 
   /**
-   * Returns a block's tree-spcific JSON representation.
-   * @return {!Object} The tree-spcific JSON representation of the block.
+   * Returns a block's navigation tree-spcific JSON representation.
+   * @return {!Object} The navigation tree-spcific JSON for the block.
    */
-  getTreeJson() {
+  getNavTreeJson() {
     return {
       'id': this.type(),
       'text': this.type()

--- a/src/model/block_definition.js
+++ b/src/model/block_definition.js
@@ -60,10 +60,10 @@ class BlockDefinition extends Resource {
   }
 
   /**
-   * Returns a block's JSON representation.
-   * @return {!Object} JSON representation of the block.
+   * Returns a block's tree-spcific JSON representation.
+   * @return {!Object} The tree-spcific JSON representation of the block.
    */
-  getJson() {
+  getTreeJson() {
     return {
       'id': this.type(),
       'text': this.type()

--- a/src/model/block_definition.js
+++ b/src/model/block_definition.js
@@ -60,8 +60,8 @@ class BlockDefinition extends Resource {
   }
 
   /**
-   * Returns a block's navigation tree-spcific JSON representation.
-   * @return {!Object} The navigation tree-spcific JSON for the block.
+   * Returns a block's navigation tree-specific JSON representation.
+   * @return {!Object} The navigation tree-specific JSON for the block.
    */
   getNavTreeJson() {
     return {

--- a/src/model/block_library.js
+++ b/src/model/block_library.js
@@ -162,7 +162,7 @@ class BlockLibrary extends Resource {
    *     tree.
    * @return {!Object} The tree-specific JSON representation of the library.
    */
-  getJson() {
+  getTreeJson() {
     const libraryJson = $.extend(true, super.getJson(),
       {'id': PREFIXES.LIBRARY, 'children': this.getBlockArrayJson()});
     return libraryJson;

--- a/src/model/block_library.js
+++ b/src/model/block_library.js
@@ -162,7 +162,7 @@ class BlockLibrary extends Resource {
    *     tree.
    * @return {!Object} The tree-specific JSON representation of the library.
    */
-  getTreeJson() {
+  getNavTreeJson() {
     const libraryJson = $.extend(true, super.getJson(),
       {'id': PREFIXES.LIBRARY, 'children': this.getBlockArrayJson()});
     return libraryJson;

--- a/src/model/block_library_set.js
+++ b/src/model/block_library_set.js
@@ -95,10 +95,10 @@ class BlockLibrarySet extends ResourceSet {
   }
 
   /**
-   * Produces the JSON needed to organize libraries in the tree.
-   * @return {!Object} The JSON for the tree's library section.
+   * Produces the JSON needed to organize libraries in the navigation tree.
+   * @return {!Object} The JSON for the navigation tree's library section.
    */
-  getTreeJson() {
+  getNavTreeJson() {
     const librarySetJson = {
       'id': PREFIXES.LIBRARY,
       'text': 'Libraries',

--- a/src/model/block_library_set.js
+++ b/src/model/block_library_set.js
@@ -102,7 +102,7 @@ class BlockLibrarySet extends ResourceSet {
     const librarySetJson = {
       'id': PREFIXES.LIBRARY,
       'text': 'Libraries',
-      'children': super.getTreeJson()
+      'children': super.getNavTreeJson()
     };
     return librarySetJson;
   }

--- a/src/model/block_library_set.js
+++ b/src/model/block_library_set.js
@@ -98,11 +98,11 @@ class BlockLibrarySet extends ResourceSet {
    * Produces the JSON needed to organize libraries in the tree.
    * @return {!Object} The JSON for the tree's library section.
    */
-  getJson() {
+  getTreeJson() {
     const librarySetJson = {
       'id': PREFIXES.LIBRARY,
       'text': 'Libraries',
-      'children': super.getJson()
+      'children': super.getTreeJson()
     };
     return librarySetJson;
   }

--- a/src/model/project.js
+++ b/src/model/project.js
@@ -264,7 +264,7 @@ class Project extends Resource {
    * @return {!Object} The tree-specific JSON representation of the project.
    */
   getNavTreeJson() {
-    const projectJson = $.extend(true, super.getTreeJson(),
+    const projectJson = $.extend(true, super.getNavTreeJson(),
       { 'id': PREFIXES.PROJECT, 'text': this.name,
         'children': [ this.librarySet.getNavTreeJson(),
           this.toolboxSet.getNavTreeJson(),

--- a/src/model/project.js
+++ b/src/model/project.js
@@ -263,13 +263,13 @@ class Project extends Resource {
    *     tree.
    * @return {!Object} The tree-specific JSON representation of the project.
    */
-  getJson() {
-    const projectJson = $.extend(true, super.getJson(),
+  getTreeJson() {
+    const projectJson = $.extend(true, super.getTreeJson(),
       { 'id': PREFIXES.PROJECT, 'text': this.name,
-        'children': [ this.librarySet.getJson(),
-          this.toolboxSet.getJson(),
-          this.workspaceContentsSet.getJson(),
-          this.workspaceConfigSet.getJson()]}
+        'children': [ this.librarySet.getTreeJson(),
+          this.toolboxSet.getTreeJson(),
+          this.workspaceContentsSet.getTreeJson(),
+          this.workspaceConfigSet.getTreeJson()]}
     );
     return projectJson;
   }

--- a/src/model/project.js
+++ b/src/model/project.js
@@ -263,13 +263,13 @@ class Project extends Resource {
    *     tree.
    * @return {!Object} The tree-specific JSON representation of the project.
    */
-  getTreeJson() {
+  getNavTreeJson() {
     const projectJson = $.extend(true, super.getTreeJson(),
       { 'id': PREFIXES.PROJECT, 'text': this.name,
-        'children': [ this.librarySet.getTreeJson(),
-          this.toolboxSet.getTreeJson(),
-          this.workspaceContentsSet.getTreeJson(),
-          this.workspaceConfigSet.getTreeJson()]}
+        'children': [ this.librarySet.getNavTreeJson(),
+          this.toolboxSet.getNavTreeJson(),
+          this.workspaceContentsSet.getNavTreeJson(),
+          this.workspaceConfigSet.getNavTreeJson()]}
     );
     return projectJson;
   }

--- a/src/model/resource.js
+++ b/src/model/resource.js
@@ -72,9 +72,9 @@ class Resource {
   }
 
   /**
-   * Gets the navigation tree-spcific JSON object which represents the resource.
+   * Gets the navigation tree-specific JSON object which represents the resource.
    *
-   * @return {!Object} The tree-spcific JSON representation of the resource.
+   * @return {!Object} The tree-specific JSON representation of the resource.
    */
   getNavTreeJson() {
     const resourceJson = {

--- a/src/model/resource.js
+++ b/src/model/resource.js
@@ -72,11 +72,11 @@ class Resource {
   }
 
   /**
-   * Gets the JSON object which represents the resource.
+   * Gets the tree-spcific JSON object which represents the resource.
    *
-   * @return {!Object} The JSON representation of the resource.
+   * @return {!Object} The tree-spcific JSON representation of the resource.
    */
-  getJson() {
+  getTreeJson() {
     const resourceJson = {
       'text': this.name,
     };

--- a/src/model/resource.js
+++ b/src/model/resource.js
@@ -72,11 +72,11 @@ class Resource {
   }
 
   /**
-   * Gets the tree-spcific JSON object which represents the resource.
+   * Gets the navigation tree-spcific JSON object which represents the resource.
    *
    * @return {!Object} The tree-spcific JSON representation of the resource.
    */
-  getTreeJson() {
+  getNavTreeJson() {
     const resourceJson = {
       'text': this.name,
     };

--- a/src/model/resource_set.js
+++ b/src/model/resource_set.js
@@ -95,13 +95,13 @@ goog.require('Resource');
   }
 
   /**
-   * Returns the tree-spcific JSON representation of the resource set.
+   * Returns the navigation tree-spcific JSON representation of the resource set.
    * @return {!Object} The JSON representing the set.
    */
-  getTreeJson() {
+  getNavTreeJson() {
     let resourceSetJson = [];
     for (let resourceName of this.getNames()) {
-      var resourceJson = this.resources[resourceName].getTreeJson();
+      var resourceJson = this.resources[resourceName].getNavTreeJson();
       resourceSetJson.push(resourceJson);
     }
     return resourceSetJson;

--- a/src/model/resource_set.js
+++ b/src/model/resource_set.js
@@ -95,7 +95,7 @@ goog.require('Resource');
   }
 
   /**
-   * Returns the navigation tree-spcific JSON representation of the resource set.
+   * Returns the navigation tree-specific JSON representation of the resource set.
    * @return {!Object} The JSON representing the set.
    */
   getNavTreeJson() {

--- a/src/model/resource_set.js
+++ b/src/model/resource_set.js
@@ -95,13 +95,13 @@ goog.require('Resource');
   }
 
   /**
-   * Returns the JSON representation of the resource set.
+   * Returns the tree-spcific JSON representation of the resource set.
    * @return {!Object} The JSON representing the set.
    */
-  getJson() {
+  getTreeJson() {
     let resourceSetJson = [];
     for (let resourceName of this.getNames()) {
-      var resourceJson = this.resources[resourceName].getJson();
+      var resourceJson = this.resources[resourceName].getTreeJson();
       resourceSetJson.push(resourceJson);
     }
     return resourceSetJson;

--- a/src/model/toolbox.js
+++ b/src/model/toolbox.js
@@ -428,8 +428,8 @@ class Toolbox extends Resource {
    *     tree.
    * @return {!Object} The tree-specific JSON representation of the toolbox.
    */
-  getTreeJson() {
-    const treeJson = $.extend(true, super.getTreeJson(),
+  getNavTreeJson() {
+    const treeJson = $.extend(true, super.getNavTreeJson(),
       {'id': PREFIXES.TOOLBOX});
     return treeJson;
   }

--- a/src/model/toolbox.js
+++ b/src/model/toolbox.js
@@ -429,7 +429,9 @@ class Toolbox extends Resource {
    * @return {!Object} The tree-specific JSON representation of the toolbox.
    */
   getTreeJson() {
-    throw "unimplemented: getTreeJson";
+    const treeJson = $.extend(true, super.getTreeJson(),
+      {'id': PREFIXES.TOOLBOX});
+    return treeJson;
   }
 
   /**

--- a/src/model/toolbox_set.js
+++ b/src/model/toolbox_set.js
@@ -70,11 +70,11 @@ class ToolboxSet extends ResourceSet {
    * Produces the JSON needed to organize toolboxes in the tree.
    * @return {!Object} The JSON for the toolbox set.
    */
-  getJson() {
+  getTreeJson() {
     const toolboxSetJson = {
       'id': PREFIXES.TOOLBOX,
       'text': 'Toolboxes',
-      'children': super.getJson()
+      'children': super.getTreeJson()
     };
     return toolboxSetJson;
   }

--- a/src/model/toolbox_set.js
+++ b/src/model/toolbox_set.js
@@ -67,14 +67,14 @@ class ToolboxSet extends ResourceSet {
   }
 
   /**
-   * Produces the JSON needed to organize toolboxes in the tree.
-   * @return {!Object} The JSON for the toolbox set.
+   * Produces the JSON needed to organize toolboxes in the navigation tree.
+   * @return {!Object} The navigation tree JSON for the toolbox set.
    */
-  getTreeJson() {
+  getNavTreeJson() {
     const toolboxSetJson = {
       'id': PREFIXES.TOOLBOX,
       'text': 'Toolboxes',
-      'children': super.getTreeJson()
+      'children': super.getNavTreeJson()
     };
     return toolboxSetJson;
   }

--- a/src/model/workspace_configuration.js
+++ b/src/model/workspace_configuration.js
@@ -72,9 +72,10 @@ class WorkspaceConfiguration extends Resource {
   /**
    * Gets the JSON object necessary to represent the workspace configuration in
    *     the navigation tree.
-   * @return {!Object} The JSON representation of the workspace configuration.
+   * @return {!Object} The tree-spcific JSON representation of the workspace
+   * configuration.
    */
-  getJson() {
+  getTreeJson() {
     const workspaceConfigJson = $.extend(true, super.getJson(),
       {'id': PREFIXES.WORKSPACE_CONFIG});
     return workspaceConfigJson;

--- a/src/model/workspace_configuration.js
+++ b/src/model/workspace_configuration.js
@@ -75,8 +75,8 @@ class WorkspaceConfiguration extends Resource {
    * @return {!Object} The tree-spcific JSON representation of the workspace
    * configuration.
    */
-  getTreeJson() {
-    const workspaceConfigJson = $.extend(true, super.getJson(),
+  getNavTreeJson() {
+    const workspaceConfigJson = $.extend(true, super.getNavJson(),
       {'id': PREFIXES.WORKSPACE_CONFIG});
     return workspaceConfigJson;
   }

--- a/src/model/workspace_configuration_set.js
+++ b/src/model/workspace_configuration_set.js
@@ -40,14 +40,15 @@ class WorkspaceConfigurationSet extends ResourceSet {
   }
 
   /**
-   * Produces the tree-spcific JSON that represents the workspace configuration set.
+   * Produces the navigation tree-spcific JSON that represents the workspace
+   * configuration set.
    * @return {!Object} The JSON for the workspace configuration set.
    */
-  getTreeJson() {
+  getNavTreeJson() {
     const workspaceConfigSetJson = {
       'id': PREFIXES.WORKSPACE_CONFIG,
       'text': 'Workspace Configurations',
-      'children': super.getTreeJson()
+      'children': super.getNavTreeJson()
     };
     return workspaceConfigSetJson;
   }

--- a/src/model/workspace_configuration_set.js
+++ b/src/model/workspace_configuration_set.js
@@ -43,11 +43,11 @@ class WorkspaceConfigurationSet extends ResourceSet {
    * Produces the JSON that represents the workspace configuration set.
    * @return {!Object} The JSON for the workspace configuration set.
    */
-  getJson() {
+  getTreeJson() {
     const workspaceConfigSetJson = {
       'id': PREFIXES.WORKSPACE_CONFIG,
       'text': 'Workspace Configurations',
-      'children': super.getJson()
+      'children': super.getTreeJson()
     };
     return workspaceConfigSetJson;
   }

--- a/src/model/workspace_configuration_set.js
+++ b/src/model/workspace_configuration_set.js
@@ -40,7 +40,7 @@ class WorkspaceConfigurationSet extends ResourceSet {
   }
 
   /**
-   * Produces the JSON that represents the workspace configuration set.
+   * Produces the tree-spcific JSON that represents the workspace configuration set.
    * @return {!Object} The JSON for the workspace configuration set.
    */
   getTreeJson() {

--- a/src/model/workspace_contents.js
+++ b/src/model/workspace_contents.js
@@ -72,8 +72,8 @@ class WorkspaceContents extends Resource {
   }
 
   /**
-   * Gets the tree-spcific JSON object necessary to represent the workspace
-   * contents in the navigation tree.
+   * Gets the JSON object necessary to represent the workspace contents in the
+   * navigation tree.
    * @return {!Object} The tree-spcific JSON representation of the workspace
    * contents.
    */

--- a/src/model/workspace_contents.js
+++ b/src/model/workspace_contents.js
@@ -72,11 +72,12 @@ class WorkspaceContents extends Resource {
   }
 
   /**
-   * Gets the JSON object necessary to represent the workspace contents in the
-   *     navigation tree.
-   * @return {!Object} The JSON representation of the workspace contents.
+   * Gets the tree-spcific JSON object necessary to represent the workspace
+   * contents in the navigation tree.
+   * @return {!Object} The tree-spcific JSON representation of the workspace
+   * contents.
    */
-  getJson() {
+  getTreeJson() {
     const workspaceContentsJson = $.extend(true, super.getJson(),
       {'id': PREFIXES.WORKSPACE_CONTENTS});
     return workspaceContentsJson;

--- a/src/model/workspace_contents.js
+++ b/src/model/workspace_contents.js
@@ -74,7 +74,7 @@ class WorkspaceContents extends Resource {
   /**
    * Gets the JSON object necessary to represent the workspace contents in the
    * navigation tree.
-   * @return {!Object} The tree-spcific JSON representation of the workspace
+   * @return {!Object} The tree-specific JSON representation of the workspace
    * contents.
    */
   getNavTreeJson() {

--- a/src/model/workspace_contents.js
+++ b/src/model/workspace_contents.js
@@ -77,8 +77,8 @@ class WorkspaceContents extends Resource {
    * @return {!Object} The tree-spcific JSON representation of the workspace
    * contents.
    */
-  getTreeJson() {
-    const workspaceContentsJson = $.extend(true, super.getJson(),
+  getNavTreeJson() {
+    const workspaceContentsJson = $.extend(true, super.getNavJson(),
       {'id': PREFIXES.WORKSPACE_CONTENTS});
     return workspaceContentsJson;
   }

--- a/src/model/workspace_contents_set.js
+++ b/src/model/workspace_contents_set.js
@@ -51,11 +51,11 @@ class WorkspaceContentsSet extends ResourceSet {
    * Produces the JSON that represents the workspace contents set.
    * @return {!Object} The JSON for workspace contents set.
    */
-  getJson() {
+  getTreeJson() {
     const workspaceContentsSetJson = {
       'id': PREFIXES.WORKSPACE_CONTENTS,
       'text': 'Workspace Contents',
-      'children': super.getJson()
+      'children': super.getTreeJson()
     };
     return workspaceContentsSetJson;
   }

--- a/src/model/workspace_contents_set.js
+++ b/src/model/workspace_contents_set.js
@@ -48,7 +48,7 @@ class WorkspaceContentsSet extends ResourceSet {
   }
 
   /**
-   * Produces the JSON that represents the workspace contents set.
+   * Produces the tree-spcific JSON that represents the workspace contents set.
    * @return {!Object} The JSON for workspace contents set.
    */
   getTreeJson() {

--- a/src/model/workspace_contents_set.js
+++ b/src/model/workspace_contents_set.js
@@ -48,14 +48,15 @@ class WorkspaceContentsSet extends ResourceSet {
   }
 
   /**
-   * Produces the tree-spcific JSON that represents the workspace contents set.
+   * Produces the navigation tree-spcific JSON that represents the workspace
+   * contents set.
    * @return {!Object} The JSON for workspace contents set.
    */
-  getTreeJson() {
+  getNavTreeJson() {
     const workspaceContentsSetJson = {
       'id': PREFIXES.WORKSPACE_CONTENTS,
       'text': 'Workspace Contents',
-      'children': super.getTreeJson()
+      'children': super.getNavTreeJson()
     };
     return workspaceContentsSetJson;
   }

--- a/src/view/navigation_tree.js
+++ b/src/view/navigation_tree.js
@@ -51,7 +51,7 @@ class NavigationTree {
    * @return {!Object} The JSON necessary to load the tree.
    */
   makeTreeJson() {
-    const data = this.appController.project.getTreeJson();
+    const data = this.appController.project.getNavTreeJson();
     const tree = {
       'core': {
         'check_callback': true,

--- a/src/view/navigation_tree.js
+++ b/src/view/navigation_tree.js
@@ -51,7 +51,7 @@ class NavigationTree {
    * @return {!Object} The JSON necessary to load the tree.
    */
   makeTreeJson() {
-    const data = this.appController.project.getJson();
+    const data = this.appController.project.getTreeJson();
     const tree = {
       'core': {
         'check_callback': true,


### PR DESCRIPTION
In the course of restoring block definition JSON functionality, I'll run in to issues with the concision of method naming if the tree-specific JSON methods are still getJson. Thus this PR changes them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/179)
<!-- Reviewable:end -->
