### PR TITLE
[Bugfix] Block Editor: Renaming Blocks

### DIFF
--- a/src/view/navigation_tree.js
+++ b/src/view/navigation_tree.js
@@ -306,8 +306,8 @@ class NavigationTree {
       const library = this.appController.project.getBlockLibrary(name);
       const blockDef = library.getBlockDefinition(Object.keys(library.blocks)[0]);
       if (blockDef) {
-        this.appController.switchEnvironment(AppController.BLOCK_EDITOR,
-            library.getBlockDefinition(Object.keys(library.blocks)[0]));
+        this.getTree().deselect_all();
+        this.getTree().select_node(PREFIXES.BLOCK + '_' + blockDef.type());
       }
     } else if (prefix === PREFIXES.TOOLBOX) {
       this.appController.switchEnvironment(AppController.TOOLBOX_EDITOR,


### PR DESCRIPTION
Bug: select library node --> Automatically loads the first block. However, renaming the block will then change the name of the library in the navtree.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/185)
<!-- Reviewable:end -->
