### PR TITLE
Toolbox/Workspace Editor: Block Library Categories

### DIFF
--- a/res/devtools_toolboxes.js
+++ b/res/devtools_toolboxes.js
@@ -32,15 +32,13 @@ goog.provide('DevToolsToolboxes');
  * user-created block libraries as categories in toolbox and workspace editors.
  *
  * @param {string} libraryName Name of library.
- * @param {string} libraryXml XML string of the blocks in a given library.
+ * @param {!Element} libraryXml XML of the blocks in a given library.
  * @return {string} XML string of category which contains the blocks in the library.
  */
 DevToolsToolboxes.createCategoryElement_ = function(libraryName, libraryXml) {
-  const categoryXml = `<category name="${libraryName}" colour="260">
-    ${libraryXml}
-  </category>
+  const categoryXml = `
+  ${Blockly.Xml.domToPrettyText(libraryXml)}
   `;
-  console.log(categoryXml);
   return categoryXml;
 };
 
@@ -49,20 +47,19 @@ DevToolsToolboxes.createCategoryElement_ = function(libraryName, libraryXml) {
  *
  * @param {!Array.<Object>} blockLibraryList Array of associative two-element arrays
  *     in which the first element is the block library name and the second is
- *     its XML string. Inserted into blockLibrary category of toolbox XML.
+ *     its XML. Inserted into blockLibrary category of toolbox XML.
  * @return {string} String representation of XML for toolbox used in creating
  *     custom Toolboxes and WorkspaceContents.
  */
 DevToolsToolboxes.toolboxEditor = function(blockLibraryList) {
-  // let blockLibraryXmls = '';
-  // // If null, no additional library category is created.
-  // if (blockLibraryList) {
-  //   blockLibraryList.forEach((blockLibPair) => {
-  //     blockLibraryXmls += DevToolsToolboxes.createCategoryElement_(
-  //         blockLibPair[0], blockLibPair[1]);
-  //   });
-  // }
-  let blockLibraryXmls = blockLibraryList;
+  let blockLibraryXmls = '';
+  // If null, no additional library category is created.
+  if (blockLibraryList) {
+    blockLibraryList.forEach((blockLibPair) => {
+      blockLibraryXmls += DevToolsToolboxes.createCategoryElement_(
+          blockLibPair[0], blockLibPair[1]);
+    });
+  }
 
   return `
 <xml id="workspacefactory_toolbox" class="toolbox">

--- a/res/devtools_toolboxes.js
+++ b/res/devtools_toolboxes.js
@@ -52,7 +52,7 @@ DevToolsToolboxes.createCategoryElement_ = function(libraryName, libraryXml) {
  *     custom Toolboxes and WorkspaceContents.
  */
 DevToolsToolboxes.toolboxEditor = function(blockLibraryList) {
-  const blockLibraryXmls = '';
+  let blockLibraryXmls = '';
   // If null, no additional library category is created.
   if (blockLibraryList) {
     blockLibraryList.forEach((blockLibPair) => {

--- a/res/devtools_toolboxes.js
+++ b/res/devtools_toolboxes.js
@@ -27,22 +27,6 @@
 goog.provide('DevToolsToolboxes');
 
 /**
- * Creates category XML with library name and category color of a given block
- * library. Helper function for DevToolsToolboxes.toolboxEditor(). Used to display
- * user-created block libraries as categories in toolbox and workspace editors.
- *
- * @param {string} libraryName Name of library.
- * @param {!Element} libraryXml XML of the blocks in a given library.
- * @return {string} XML string of category which contains the blocks in the library.
- */
-DevToolsToolboxes.createCategoryElement_ = function(libraryName, libraryXml) {
-  const categoryXml = `
-  ${Blockly.Xml.domToPrettyText(libraryXml)}
-  `;
-  return categoryXml;
-};
-
-/**
  * Generates XML string for toolbox editor. Used in ToolboxView and WorkspaceView.
  *
  * @param {!Array.<Object>} blockLibraryList Array of associative two-element arrays
@@ -56,8 +40,7 @@ DevToolsToolboxes.toolboxEditor = function(blockLibraryList) {
   // If null, no additional library category is created.
   if (blockLibraryList) {
     blockLibraryList.forEach((blockLibPair) => {
-      blockLibraryXmls += DevToolsToolboxes.createCategoryElement_(
-          blockLibPair[0], blockLibPair[1]);
+      blockLibraryXmls += Blockly.Xml.domToPrettyText(blockLibPair[1]);
     });
   }
 

--- a/res/devtools_toolboxes.js
+++ b/res/devtools_toolboxes.js
@@ -36,10 +36,12 @@ goog.provide('DevToolsToolboxes');
  * @return {string} XML string of category which contains the blocks in the library.
  */
 DevToolsToolboxes.createCategoryElement_ = function(libraryName, libraryXml) {
-  return `<category name="${libraryName}" colour="260">
+  const categoryXml = `<category name="${libraryName}" colour="260">
     ${libraryXml}
   </category>
   `;
+  console.log(categoryXml);
+  return categoryXml;
 };
 
 /**

--- a/res/devtools_toolboxes.js
+++ b/res/devtools_toolboxes.js
@@ -54,14 +54,15 @@ DevToolsToolboxes.createCategoryElement_ = function(libraryName, libraryXml) {
  *     custom Toolboxes and WorkspaceContents.
  */
 DevToolsToolboxes.toolboxEditor = function(blockLibraryList) {
-  let blockLibraryXmls = '';
-  // If null, no additional library category is created.
-  if (blockLibraryList) {
-    blockLibraryList.forEach((blockLibPair) => {
-      blockLibraryXmls += DevToolsToolboxes.createCategoryElement_(
-          blockLibPair[0], blockLibPair[1]);
-    });
-  }
+  // let blockLibraryXmls = '';
+  // // If null, no additional library category is created.
+  // if (blockLibraryList) {
+  //   blockLibraryList.forEach((blockLibPair) => {
+  //     blockLibraryXmls += DevToolsToolboxes.createCategoryElement_(
+  //         blockLibPair[0], blockLibPair[1]);
+  //   });
+  // }
+  let blockLibraryXmls = blockLibraryList;
 
   return `
 <xml id="workspacefactory_toolbox" class="toolbox">

--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -196,9 +196,8 @@ class BlockEditorController {
     // Sets JSON field of BlockDefinition object.
     // TODO(#190): Store and generate block definition JSONs more efficiently to
     // avoid repeatedly using JSON.parse().
-    const jsonString = FactoryUtils.getBlockDefinition(
+    currentBlock.json = FactoryUtils.getBlockDefinition(
           'JSON', this.view.editorWorkspace);
-    currentBlock.json = JSON.parse(jsonString);
   }
 
   /**

--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -101,6 +101,7 @@ class BlockEditorController {
     // Creates new BlockDefinition object.
     const newBlock = this.projectController.createBlockDefinition(
         blockTypeName, libraryName);
+    newBlock.define();
 
     // Sets XML in BlockDefinition model object.
     const starterXml = Blockly.Xml.textToDom(
@@ -110,6 +111,21 @@ class BlockEditorController {
     // Shows onto view.
     this.view.show(newBlock);
     this.refreshPreviews();
+  }
+
+  /**
+   * Handles response to editor workspace change events.
+   * @param {!Event} event Change event in editor workspace.
+   */
+  onChange(event) {
+    // Save block's changes into BlockDefinition model object.
+    this.updateBlockDefinition();
+    const changeTree = event.type == Blockly.Events.UI;
+    this.updateBlockName(!changeTree);
+    // Update the block editor view.
+    this.refreshPreviews();
+    // Disable orphans.
+    Blockly.Events.disableOrphans(event);
   }
 
   /**
@@ -174,10 +190,13 @@ class BlockEditorController {
   updateBlockDefinition() {
     const currentBlock = this.view.blockDefinition;
     const rootBlock = FactoryUtils.getRootBlock(this.view.editorWorkspace);
+    // Sets XML field of BlockDefinition object.
     const blockXml = '<xml>' + Blockly.Xml.domToText(Blockly.Xml.blockToDom(rootBlock)) + '</xml>';
     currentBlock.setXml(Blockly.Xml.textToDom(blockXml));
-    currentBlock.json = FactoryUtils.getBlockDefinition(
+    // Sets JSON field of BlockDefinition object.
+    const jsonString = FactoryUtils.getBlockDefinition(
           'JSON', this.view.editorWorkspace);
+    currentBlock.json = JSON.parse(jsonString);
   }
 
   /**
@@ -261,7 +280,7 @@ class BlockEditorController {
     const backupBlocks = Blockly.Blocks;
     try {
       // Evaluates block definition (temporarily) for preview.
-      this.evaluateBlock_(format, code);
+      this.view.blockDefinition.define();
 
       const blockType = this.view.blockDefinition.type();
       // Render preview block in preview workspace.
@@ -270,6 +289,7 @@ class BlockEditorController {
       this.maybeWarnUser_(blockType);
     } finally {
       Blockly.Blocks = backupBlocks;
+      this.view.blockDefinition.undefine();
     }
   }
 

--- a/src/controller/editor_controller.js
+++ b/src/controller/editor_controller.js
@@ -98,6 +98,7 @@ class EditorController {
       this.currentEditor.updateEditorToolbox();
     } else if (editor instanceof WorkspaceController) {
       this.currentEditor.loadWorkspace(this.currentEditor.view.workspaceContents);
+      this.currentEditor.updateEditorToolbox();
     }
   }
 

--- a/src/controller/editor_controller.js
+++ b/src/controller/editor_controller.js
@@ -95,6 +95,7 @@ class EditorController {
       this.currentEditor.refreshPreviews();
     } else if (editor instanceof ToolboxController) {
       this.currentEditor.loadToolbox(this.currentEditor.view.toolbox);
+      this.currentEditor.updateEditorToolbox();
     } else if (editor instanceof WorkspaceController) {
       // TODO: Add if necessary, delete if no other action is necessary.
     }

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -501,15 +501,26 @@ class ToolboxController extends ShadowController {
    * Updates the editor toolbox to have categories for user-defined block libraries.
    */
   updateEditorToolbox() {
-    // const newToolboxXml = FactoryUtils.updateBlockLibCategory(
+    // const libraryXmlStrings = FactoryUtils.updateBlockLibCategory(
     //     this.projectController.getProject(), this.hiddenWorkspace);
-    let libraryXmlStrings = '';
-    const libraryMap = this.projectController.getProject().librarySet.resources;
-    for (let libName in libraryMap) {
-      libraryXmlStrings += Blockly.Xml.domToPrettyText(
-          libraryMap[libName].getLibraryXml()) + '\n';
+
+    // let libraryXmlStrings = '';
+    // const libraryMap = this.projectController.getProject().librarySet.resources;
+    // for (let libName in libraryMap) {
+    //   libraryXmlStrings += Blockly.Xml.domToPrettyText(
+    //       libraryMap[libName].getLibraryXml()) + '\n';
+    // }
+
+    const libraryXml = [];
+    const project = this.projectController.getProject();
+    const libMap = project.librarySet.resources;
+    for (let libName in libMap) {
+      const blocks = FactoryUtils.convertToBlocklyBlocks(
+          libMap[libName].getAllBlockDefinitions(), this.hiddenWorkspace);
+      const libXml = FactoryUtils.generateCategoryXml(blocks, libName);
+      libraryXml.push([libName, libXml]);
     }
-    this.view.updateEditorToolbox(libraryXmlStrings);
+    this.view.updateEditorToolbox(libraryXml);
   }
 
   /**

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -501,9 +501,15 @@ class ToolboxController extends ShadowController {
    * Updates the editor toolbox to have categories for user-defined block libraries.
    */
   updateEditorToolbox() {
-    const newToolboxXml = FactoryUtils.updateBlockLibCategory(
-        this.projectController.getProject(), this.hiddenWorkspace);
-    this.view.updateEditorToolbox(newToolboxXml);
+    // const newToolboxXml = FactoryUtils.updateBlockLibCategory(
+    //     this.projectController.getProject(), this.hiddenWorkspace);
+    let libraryXmlStrings = '';
+    const libraryMap = this.projectController.getProject().librarySet.resources;
+    for (let libName in libraryMap) {
+      libraryXmlStrings += Blockly.Xml.domToPrettyText(
+          libraryMap[libName].getLibraryXml()) + '\n';
+    }
+    this.view.updateEditorToolbox(libraryXmlStrings);
   }
 
   /**

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -501,16 +501,6 @@ class ToolboxController extends ShadowController {
    * Updates the editor toolbox to have categories for user-defined block libraries.
    */
   updateEditorToolbox() {
-    // const libraryXmlStrings = FactoryUtils.updateBlockLibCategory(
-    //     this.projectController.getProject(), this.hiddenWorkspace);
-
-    // let libraryXmlStrings = '';
-    // const libraryMap = this.projectController.getProject().librarySet.resources;
-    // for (let libName in libraryMap) {
-    //   libraryXmlStrings += Blockly.Xml.domToPrettyText(
-    //       libraryMap[libName].getLibraryXml()) + '\n';
-    // }
-
     const libraryXml = [];
     const project = this.projectController.getProject();
     const libMap = project.librarySet.resources;

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -192,9 +192,16 @@ class WorkspaceController extends ShadowController {
    * Updates the editor toolbox to have categories for user-defined block libraries.
    */
   updateEditorToolbox() {
-    const newToolboxXml = FactoryUtils.updateBlockLibCategory(
-        this.projectController.getProject(), this.hiddenWorkspace);
-    this.view.updateEditorToolbox(newToolboxXml);
+    const libraryXml = [];
+    const project = this.projectController.getProject();
+    const libMap = project.librarySet.resources;
+    for (let libName in libMap) {
+      const blocks = FactoryUtils.convertToBlocklyBlocks(
+          libMap[libName].getAllBlockDefinitions(), this.hiddenWorkspace);
+      const libXml = FactoryUtils.generateCategoryXml(blocks, libName);
+      libraryXml.push([libName, libXml]);
+    }
+    this.view.updateEditorToolbox(libraryXml);
   }
 
   loadWorkspace() {

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -1194,8 +1194,8 @@ FactoryUtils.bindClick = function(element, func) {
 /*
  * Updates the block library category in the Toolbox and Workspace Editor
  * toolboxes.
- * @param project Project that is currently being edited in DevTools.
- * @return XML String of toolbox in editor workspace.
+ * @param {!Project} project Project that is currently being edited in DevTools.
+ * @return {string} XML String of toolbox in editor workspace.
  */
 FactoryUtils.updateBlockLibCategory = function(project, workspace) {
   // REFACTORED: Moved in from wfactory_controller.js

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -1190,6 +1190,7 @@ FactoryUtils.generateCategoryXml = function(blocks, categoryName) {
     categoryElement.appendChild(blockXml);
   }
   categoryElement.removeAttribute('xmlns');
+  // TODO(#192): Allow users to configure color for user-defined library categories.
   categoryElement.setAttribute('colour', '260');
   return categoryElement;
 };

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -1168,51 +1168,6 @@ FactoryUtils.bindClick = function(element, func) {
   element.addEventListener('touchend', func, true);
 };
 
-/*
- * Updates the block library category in the Toolbox and Workspace Editor
- * toolboxes.
- * @param {!Project} project Project that is currently being edited in DevTools.
- * @return {string} XML String of toolbox in editor workspace.
- */
-FactoryUtils.updateBlockLibCategory = function(project, workspace) {
-  // REFACTORED: Moved in from wfactory_controller.js
-  const libraryXmls = [];
-  // Alphabetized array of block library names.
-  const libraryNames = project.getBlockLibraryNames();
-
-  libraryNames.forEach((libraryName) => {
-    const library = project.getBlockLibrary(libraryName);
-    const libXml = FactoryUtils.getCategoryXml(library, workspace);
-    libraryXmls.push([
-        libraryName, Blockly.Xml.domToPrettyText(libXml)]);
-  });
-
-  return DevToolsToolboxes.toolboxEditor(libraryXmls);
-};
-
-/**
- * Creates XML toolbox category of all blocks in this block library. Used in
- * toolbox and workspace editor.
- * @param {!BlockLibrary} library Library object to be created into an editor
- *     toolbox category.
- * @param {!Blockly.Workspace} workspace Blockly workspace used to generate and
- *     store Blockly.Block types.
- * @return {!Element} XML representation of the block library category.
- */
-FactoryUtils.getCategoryXml = function(library, workspace) {
-  // Moved in from block_exporter_tools.js:generateCategoryFromBlockLib(blockLibStorage)
-  const allBlockTypes = library.getBlockTypes();
-  const blockXmlMap = library.getBlockXmlMap(allBlockTypes);
-
-  const blocks = [];
-  for (const blockType in blockXmlMap) {
-    const block = FactoryUtils.getDefinedBlock(
-        blockType, workspace);
-    blocks.push(block);
-  }
-  return FactoryUtils.generateCategoryXml(blocks, library.name);
-};
-
 /**
  * Generates a category containing blocks of the specified block types.
  * @param {!Array.<!Blockly.Block>} blocks Blocks to include in the category.
@@ -1244,8 +1199,8 @@ FactoryUtils.generateCategoryXml = function(blocks, categoryName) {
  * to use in a Blockly workspace.
  * @param {!Array.<!BlockDefinition>} blockDefinitions Array of BlockDefinition
  *     objects to convert to Blockly blocks.
- * @param {!Blockly.Workspace} workspace Hidden workspace used to generate Blockly
- *     object.
+ * @param {!Blockly.Workspace} workspace Hidden workspace used to generate
+ *     Blockly.Block objects.
  * @return {!Array<!Blockly.Block>} Array of Blockly blocks that correspond to
  *     the BlockDefinition objects.
  */

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -768,30 +768,6 @@ FactoryUtils.getBlockTypeFromJsDefinition = function(blockDef) {
 };
 
 /**
- * Generates a category containing blocks of the specified block types.
- * @param {!Array.<!Blockly.Block>} blocks Blocks to include in the category.
- * @param {string} categoryName Name to use for the generated category.
- * @return {!Element} Category XML containing the given block types.
- */
-FactoryUtils.generateCategoryXml = function(blocks, categoryName) {
-  // Create category DOM element.
-  var categoryElement = goog.dom.createDom('category');
-  categoryElement.setAttribute('name', categoryName);
-
-  // For each block, add block element to category.
-  for (var i = 0, block; block = blocks[i]; i++) {
-
-    // Get preview block XML.
-    var blockXml = Blockly.Xml.blockToDom(block);
-    blockXml.removeAttribute('id');
-
-    // Add block to category and category to XML.
-    categoryElement.appendChild(blockXml);
-  }
-  return categoryElement;
-};
-
-/**
  * Parses a string containing JavaScript block definition(s) to create an array
  * in which each element is a single block definition.
  * @param {string} blockDefsString JavaScript block definition(s).
@@ -1201,12 +1177,13 @@ FactoryUtils.updateBlockLibCategory = function(project, workspace) {
   // REFACTORED: Moved in from wfactory_controller.js
   const libraryXmls = [];
   // Alphabetized array of block library names.
-  const libraryNames = project.getLibraryNames();
+  const libraryNames = project.getBlockLibraryNames();
 
   libraryNames.forEach((libraryName) => {
-    const library = project.getLibrary(libraryName);
+    const library = project.getBlockLibrary(libraryName);
+    const libXml = FactoryUtils.getCategoryXml(library, workspace);
     libraryXmls.push([
-        libraryName, FactoryUtils.getCategoryXml(library, workspace)]);
+        libraryName, Blockly.Xml.domToPrettyText(libXml)]);
   });
 
   return DevToolsToolboxes.toolboxEditor(libraryXmls);
@@ -1232,8 +1209,31 @@ FactoryUtils.getCategoryXml = function(library, workspace) {
         blockType, workspace);
     blocks.push(block);
   }
+  return FactoryUtils.generateCategoryXml(blocks, library.name);
+};
 
-  return FactoryUtils.generateCategoryXml(blocks, 'Block Library');
+/**
+ * Generates a category containing blocks of the specified block types.
+ * @param {!Array.<!Blockly.Block>} blocks Blocks to include in the category.
+ * @param {string} categoryName Name to use for the generated category.
+ * @return {!Element} Category XML containing the given block types.
+ */
+FactoryUtils.generateCategoryXml = function(blocks, categoryName) {
+  // Create category DOM element.
+  var categoryElement = goog.dom.createDom('category');
+  categoryElement.setAttribute('name', categoryName);
+
+  // For each block, add block element to category.
+  for (var i = 0, block; block = blocks[i]; i++) {
+
+    // Get preview block XML.
+    var blockXml = Blockly.Xml.blockToDom(block);
+    blockXml.removeAttribute('id');
+
+    // Add block to category and category to XML.
+    categoryElement.appendChild(blockXml);
+  }
+  return categoryElement;
 };
 
 /*

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -742,7 +742,7 @@ FactoryUtils.createAndDownloadFile = function(contents, filename, mimeType) {
 
 /**
  * Get Blockly Block by rendering pre-defined block in workspace.
- * @param {!Element} blockType Type of block that has already been defined.
+ * @param {string} blockType Type of block that has already been defined.
  * @param {!Blockly.Workspace} workspace Workspace on which to render
  *    the block.
  * @return {!Blockly.Block} The Blockly.Block of desired type.
@@ -1234,7 +1234,28 @@ FactoryUtils.generateCategoryXml = function(blocks, categoryName) {
     // Add block to category and category to XML.
     categoryElement.appendChild(blockXml);
   }
+  categoryElement.removeAttribute('xmlns');
+  categoryElement.setAttribute('colour', '260');
   return categoryElement;
+};
+
+/**
+ * Given an array of BlockDefintion objects, converts them into Blockly.Blocks
+ * to use in a Blockly workspace.
+ * @param {!Array.<!BlockDefinition>} blockDefinitions Array of BlockDefinition
+ *     objects to convert to Blockly blocks.
+ * @param {!Blockly.Workspace} workspace Hidden workspace used to generate Blockly
+ *     object.
+ * @return {!Array<!Blockly.Block>} Array of Blockly blocks that correspond to
+ *     the BlockDefinition objects.
+ */
+FactoryUtils.convertToBlocklyBlocks = function(blockDefinitions, workspace) {
+  const blocks = [];
+  for (let blockDef of blockDefinitions) {
+    blockDef.define();
+    blocks.push(FactoryUtils.getDefinedBlock(blockDef.type(), workspace));
+  }
+  return blocks;
 };
 
 /*

--- a/src/model/block_definition.js
+++ b/src/model/block_definition.js
@@ -59,7 +59,8 @@ class BlockDefinition extends Resource {
   }
 
   /**
-   * Defines block by adding it to the Blockly.Blocks map.
+   * Defines block by adding it to the Blockly.Blocks map. Function is overwritten
+   * if the block has already been defined.
    */
   define() {
     if (this.isDefined_) {

--- a/src/model/block_definition.js
+++ b/src/model/block_definition.js
@@ -59,8 +59,8 @@ class BlockDefinition extends Resource {
   }
 
   /**
-   * Defines block by adding it to the Blockly.Blocks map. Function is overwritten
-   * if the block has already been defined.
+   * Defines block by adding it to the Blockly.Blocks map. If the block has
+   * already been defined before, nothing is executed.
    */
   define() {
     if (this.isDefined_) {

--- a/src/model/block_definition.js
+++ b/src/model/block_definition.js
@@ -32,7 +32,7 @@ class BlockDefinition extends Resource {
    * BlockDefinition Class.
    * @constructor
    * @param {string} type The name of the block.
-   * @param {?Object} opt_json optional JSON representation of the block.
+   * @param {Object=} opt_json optional JSON representation of the block.
    */
   constructor(type, opt_json) {
     super(type, PREFIXES.BLOCK);
@@ -53,8 +53,14 @@ class BlockDefinition extends Resource {
   /**
    * Defines block by adding it to the Blockly.Blocks map. Previous entry in
    * Blockly.Blocks map is overwritten if the block has already been defined before.
+   * @throws If BlockDefinition object is unnamed.
    */
   define() {
+    if (!this.name) {
+      throw 'Block definition does not have a valid name. Cannot be added to ' +
+          'Blockly.Blocks map.';
+      return;
+    }
     const json = this.json;
     Blockly.Blocks[this.name] = {
       init: function() {

--- a/src/model/block_definition.js
+++ b/src/model/block_definition.js
@@ -48,31 +48,19 @@ class BlockDefinition extends Resource {
      * @type {!Object}
      */
     this.json = opt_json || this.createStarterJson();
-
-    /**
-     * Keeps track of whether a BlockDefinition has been defined previously
-     * to prevent defining a block multiple times.
-     * @type {boolean}
-     * @private
-     */
-    this.isDefined_ = false;
   }
 
   /**
-   * Defines block by adding it to the Blockly.Blocks map. If the block has
-   * already been defined before, nothing is executed.
+   * Defines block by adding it to the Blockly.Blocks map. Previous entry in
+   * Blockly.Blocks map is overwritten if the block has already been defined before.
    */
   define() {
-    if (this.isDefined_) {
-      return;
-    }
     const json = this.json;
-    Blockly.Blocks[this.name || 'unnamed'] = {
+    Blockly.Blocks[this.name] = {
       init: function() {
         this.jsonInit(json);
       }
     };
-    this.isDefined_ = true;
   }
 
   /**
@@ -81,7 +69,6 @@ class BlockDefinition extends Resource {
   undefine() {
     if (Blockly.Blocks[this.name]) {
       delete Blockly.Blocks[this.name];
-      this.isDefined_ = false;
     }
   }
 

--- a/src/model/block_definition.js
+++ b/src/model/block_definition.js
@@ -32,7 +32,8 @@ class BlockDefinition extends Resource {
    * BlockDefinition Class.
    * @constructor
    * @param {string} type The name of the block.
-   * @param {Object=} opt_json optional JSON representation of the block.
+   * @param {string=} opt_json optional String representation block definition
+   *     JSON.
    */
   constructor(type, opt_json) {
     super(type, PREFIXES.BLOCK);
@@ -45,7 +46,7 @@ class BlockDefinition extends Resource {
 
     /**
      * The JSON representation of the block.
-     * @type {!Object}
+     * @type {string}
      */
     this.json = opt_json || this.createStarterJson();
   }
@@ -61,7 +62,7 @@ class BlockDefinition extends Resource {
           'Blockly.Blocks map.';
       return;
     }
-    const json = this.json;
+    const json = JSON.parse(this.json);
     Blockly.Blocks[this.name] = {
       init: function() {
         this.jsonInit(json);
@@ -86,7 +87,7 @@ class BlockDefinition extends Resource {
     var blockJson = Object.create(null);
     blockJson.type = this.type();
     blockJson.message0 = '';
-    return blockJson;
+    return JSON.stringify(blockJson, null, '  ');
   }
 
   /**
@@ -129,7 +130,7 @@ class BlockDefinition extends Resource {
 
   /**
    * Returns a block's JSON representation.
-   * @return {!Object} The JSON for the block.
+   * @return {string} The JSON for the block.
    */
   getBlockDefinitionJson() {
     return this.json;

--- a/src/model/block_definition.js
+++ b/src/model/block_definition.js
@@ -48,6 +48,40 @@ class BlockDefinition extends Resource {
      * @type {!Object}
      */
     this.json = opt_json || this.createStarterJson();
+
+    /**
+     * Keeps track of whether a BlockDefinition has been defined previously
+     * to prevent defining a block multiple times.
+     * @type {boolean}
+     * @private
+     */
+    this.isDefined_ = false;
+  }
+
+  /**
+   * Defines block by adding it to the Blockly.Blocks map.
+   */
+  define() {
+    if (this.isDefined_) {
+      return;
+    }
+    const json = this.json;
+    Blockly.Blocks[this.name || 'unnamed'] = {
+      init: function() {
+        this.jsonInit(json);
+      }
+    };
+    this.isDefined_ = true;
+  }
+
+  /**
+   * Undefines block by removing it from Blockly.Blocks map.
+   */
+  undefine() {
+    if (Blockly.Blocks[this.name]) {
+      delete Blockly.Blocks[this.name];
+      this.isDefined_ = false;
+    }
   }
 
   /**

--- a/src/model/block_library.js
+++ b/src/model/block_library.js
@@ -117,7 +117,7 @@ class BlockLibrary extends Resource {
   getBlockArrayJson() {
     let blockArrayJson = [];
     for (let blockType in this.getBlockTypes()) {
-      blockArrayJson.push(this.blocks[blockType].json);
+      blockArrayJson.push(JSON.parse(this.blocks[blockType].json));
     }
     return blockArrayJson;
   }

--- a/src/model/block_library.js
+++ b/src/model/block_library.js
@@ -89,6 +89,18 @@ class BlockLibrary extends Resource {
   }
 
   /**
+   * Gets all BlockDefinition objects within the library.
+   * @return {!Array.<!BlockDefinition>} Array of all BlockDefinition objects.
+   */
+  getAllBlockDefinitions() {
+    const blocks = [];
+    for (let blockName in this.blocks) {
+      blocks.push(this.get(blockName));
+    }
+    return blocks;
+  }
+
+  /**
    * Returns the XML of given block type stored in the block library.
    * @param {string} blockType Type of block.
    * @return {Element} The XML that represents the block type or null.

--- a/src/view/block_editor_view.js
+++ b/src/view/block_editor_view.js
@@ -142,14 +142,7 @@ class BlockEditorView {
    */
   init(controller) {
     this.editorWorkspace.addChangeListener((event) => {
-      // Save block's changes into BlockDefinition model object.
-      controller.updateBlockDefinition();
-      const changeTree = event.type == Blockly.Events.UI;
-      controller.updateBlockName(!changeTree);
-      // Update the block editor view.
-      controller.refreshPreviews();
-      // Disable orphans.
-      Blockly.Events.disableOrphans(event);
+      controller.onChange(event);
     });
 
     // LTR <-> RTL

--- a/src/view/navigation_tree.js
+++ b/src/view/navigation_tree.js
@@ -294,7 +294,7 @@ class NavigationTree {
    *     empty or null.
    */
   changeView(id) {
-    const nodeInfo = id.split('_');
+    const nodeInfo = id.split(/_(.+)/);
     const prefix = nodeInfo[0];
     const name = nodeInfo[1];
 

--- a/src/view/navigation_tree.js
+++ b/src/view/navigation_tree.js
@@ -51,7 +51,7 @@ class NavigationTree {
    * @return {!Object} The JSON necessary to load the tree.
    */
   makeTreeJson() {
-    const data = this.appController.project.getJson();
+    const data = this.appController.project.getNavTreeJson();
     data['state'] = {
         'opened': true
       };

--- a/src/view/toolbox_editor_view.js
+++ b/src/view/toolbox_editor_view.js
@@ -370,7 +370,7 @@ class ToolboxEditorView {
 
   /**
    * Updates the toolbox used in the toolbox editor workspace.
-   * @param {!string} libString String representation of user-created block
+   * @param {string} libString String representation of user-created block
    *     libraries to append to categories in the editor.
    */
   updateEditorToolbox(libString) {

--- a/src/view/toolbox_editor_view.js
+++ b/src/view/toolbox_editor_view.js
@@ -370,10 +370,12 @@ class ToolboxEditorView {
 
   /**
    * Updates the toolbox used in the toolbox editor workspace.
-   * @param {!string} toolbox String representation of toolbox XML to display.
+   * @param {!string} libString String representation of user-created block
+   *     libraries to append to categories in the editor.
    */
-  updateEditorToolbox(toolbox) {
-    this.editorWorkspace.updateToolbox(toolbox);
+  updateEditorToolbox(libString) {
+    const toolboxString = DevToolsToolboxes.toolboxEditor(libString);
+    this.editorWorkspace.updateToolbox(toolboxString);
   }
 
   /**

--- a/src/view/workspace_editor_view.js
+++ b/src/view/workspace_editor_view.js
@@ -335,10 +335,12 @@ class WorkspaceEditorView {
 
   /**
    * Updates the toolbox used in the toolbox editor workspace.
-   * @param {!string} toolbox String representation of toolbox XML to display.
+   * @param {string} libString String representation of user-created block
+   *     libraries to append to categories in the editor.
    */
-  updateEditorToolbox(toolbox) {
-    this.editorWorkspace.updateToolbox(toolbox);
+  updateEditorToolbox(libString) {
+    const toolboxString = DevToolsToolboxes.toolboxEditor(libString);
+    this.editorWorkspace.updateToolbox(toolboxString);
   }
 
   /**


### PR DESCRIPTION
Toolbox and workspace editor now display user-generated libraries as categories, so that they can add it into their toolbox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/189)
<!-- Reviewable:end -->
