### PR TITLE
Export: Sample Web Application

### DIFF
--- a/src/controller/app_controller.js
+++ b/src/controller/app_controller.js
@@ -311,12 +311,12 @@ class AppController {
     const injectFileContents = this.projectController.generateInjectString();
     // Get file name from user.
     const fileName = prompt('File name for sample Blockly workspace code:',
-                            'workspace.js');
+                            'workspace.html');
     if (!fileName) {
       return;
     }
 
-    FactoryUtils.createAndDownloadFile(injectFileContents, fileName, 'text/javascript');
+    FactoryUtils.createAndDownloadFile(injectFileContents, fileName, 'application/xhtml+xml');
 
     // TODO: Generate file contents for sample HTML page to create a "complete"
     //       sample blockly app, with instructions in the comments.

--- a/src/controller/app_controller.js
+++ b/src/controller/app_controller.js
@@ -310,12 +310,10 @@ class AppController {
     // Generate file contents for inject file.
     const injectFileContents = this.projectController.generateInjectString();
     // Get file name from user.
-    const fileName = prompt('File name for sample Blockly workspace code:',
-                            'my_blockly_application.html');
-    if (!fileName) {
-      return;
-    }
+    const fileName = 'my_blockly_application.html';
 
+    // TODO: Replace with node style file writing in the project's web export
+    // directory.
     FactoryUtils.createAndDownloadFile(injectFileContents,
         fileName, 'application/xhtml+xml');
   }

--- a/src/controller/app_controller.js
+++ b/src/controller/app_controller.js
@@ -304,13 +304,13 @@ class AppController {
    * Top-level function which is first called in order to create a sample
    * Blockly application with user-defined workspace, toolbox, and blocks.
    */
-  createSampleApplication() {
+  saveSampleApplication() {
     // REFACTORED: Moved in from wfactory_controller.js:exportInjectFile()
 
     // Generate file contents for inject file.
     const injectFileContents = this.projectController.generateInjectString();
     // Get file name from user.
-    const fileName = prompt('File name for starter Blockly workspace code:',
+    const fileName = prompt('File name for sample Blockly workspace code:',
                             'workspace.js');
     if (!fileName) {
       return;

--- a/src/controller/app_controller.js
+++ b/src/controller/app_controller.js
@@ -311,15 +311,13 @@ class AppController {
     const injectFileContents = this.projectController.generateInjectString();
     // Get file name from user.
     const fileName = prompt('File name for sample Blockly workspace code:',
-                            'workspace.html');
+                            'my_blockly_application.html');
     if (!fileName) {
       return;
     }
 
-    FactoryUtils.createAndDownloadFile(injectFileContents, fileName, 'application/xhtml+xml');
-
-    // TODO: Generate file contents for sample HTML page to create a "complete"
-    //       sample blockly app, with instructions in the comments.
+    FactoryUtils.createAndDownloadFile(injectFileContents,
+        fileName, 'application/xhtml+xml');
   }
 
   /**

--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -470,7 +470,6 @@ class BlockEditorController {
     let fileContents = '';
     const allBlocks = this.projectController.getProject().
         librarySet.getAllBlockDefinitionsMap();
-    console.log(allBlocks);
     for (let blockName in allBlocks) {
       const block = allBlocks[blockName];
       fileContents += '// Block definition: ' + blockName;

--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -445,10 +445,6 @@ class BlockEditorController {
     /**
      * TODO: Move in from app_controller.js
      *          Also from app_controller.js:formatBlockLibraryForExport_(blockXmlMap)
-     *
-     * References:
-     * - formatBlockLibraryForExport_()
-     * - FactoryUtils.createAndDownloadFile()
      */
 
     // TODO(#87): Remove XML's from block library import/export. Download block
@@ -456,6 +452,30 @@ class BlockEditorController {
     //            importing.
 
     throw 'Unimplemented: exportBlockLibraryToFile()';
+  }
+
+  /**
+   *
+   */
+  getLibraryJsFile() {
+    let fileContents = '';
+    const allBlocks = this.projectController.getProject().
+        librarySet.getAllBlockDefinitionsMap();
+    console.log(allBlocks);
+    for (let blockName in allBlocks) {
+      const block = allBlocks[blockName];
+      fileContents += '// Block definition: ' + blockName;
+      fileContents += `
+Blockly.Blocks['${blockName}'] = {
+  init: function() {
+    var blockJson = ${block.json};
+    this.jsonInit(blockJson);
+  }
+};
+`;
+      fileContents += '\n';
+    }
+    return fileContents;
   }
 
   /**

--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -462,7 +462,9 @@ class BlockEditorController {
   }
 
   /**
-   *
+   * Returns JavaScript scripts necessary for loading block definitions of all
+   * user-defined blocks within the project.
+   * @return {string} JavaScript block definitions of blocks within the project.
    */
   getLibraryJsFile() {
     let fileContents = '';

--- a/src/controller/project_controller.js
+++ b/src/controller/project_controller.js
@@ -395,13 +395,58 @@ class ProjectController {
    * @return {string} String representation of starter code for inject file.
    */
   generateInjectString() {
-    /*
-     * TODO: Move in from wfactory_generator.js:generateInjectString(toolboxXml)
-     *
-     * References:
-     * - N/A
-     */
-    throw 'Unimplemented: generateInjectString()';
+    // From wfactory_generator.js:generateInjectString(toolboxXml)
+    let div = 'blocklyWorkspace';
+    let fileInfo = Object.create(null);
+    const toolboxName = Object.keys(this.project.toolboxSet.resources)[0];
+    const toolbox = this.project.getToolbox(toolboxName);
+    const toolboxScript = FactoryUtils.generateXmlAsJsFile(toolbox, 'TOOLBOX');
+    fileInfo['toolbox'] = toolboxScript;
+
+    const workspaceName = Object.keys(this.project.workspaceContentsSet.resources)[0];
+    const workspace = this.project.getWorkspaceContents(workspaceName);
+    const workspaceScript = FactoryUtils.generateXmlAsJsFile(workspace, 'WORKSPACE');
+    fileInfo['workspace'] = workspaceScript;
+
+    const injectScript = this.tree.appController.editorController.
+        workspaceController.generateInjectFile(
+          workspace.config, div);
+    fileInfo['injectScript'] = injectScript;
+  }
+
+  static generateInjectFileContents(object) {
+    const toolboxScript = object.toolbox || '';
+    const workspaceScript = object.workspace || '';
+    const blockDefScript = object.blocks || '';
+    const injectScript = object.inject || '';
+    let fileContents = `
+<html>
+<title>Starter Application</title>
+<!-- Blocks -->
+<script>
+${workspaceScript}
+</script>
+<!-- Toolboxes -->
+<script>
+${toolboxScript}
+</script>
+<!-- Workspace -->
+<script>
+${workspaceScript}
+</script>
+<!-- Inject -->
+<script>
+${injectScript}
+</script>
+<body>
+  <h1>My Blockly Application</h1>
+  <div id="blocklyWorkspace">
+    <!-- Your workspace will be auto-injected here. Make sure the ID of this div
+         matches the ID specified in your inject function. -->
+  </div>
+</body>
+</html>
+`;
   }
 
   /**

--- a/src/controller/project_controller.js
+++ b/src/controller/project_controller.js
@@ -440,11 +440,11 @@ class ProjectController {
    *     a script tag, and is necessary to load that resource into the application.
    */
   generateInjectFileContents(injectInfo) {
-    // TODO: Retrieve compressed files from local filesystem, not appspot link.
     const toolboxScript = injectInfo.toolbox || '';
     const workspaceScript = injectInfo.workspace || '';
     const blockDefScript = injectInfo.blocks || '';
     const injectScript = injectInfo.inject || '';
+    // TODO: Replace blockly imports with web files.
     let fileContents = `
 <html>
 <head>

--- a/src/controller/project_controller.js
+++ b/src/controller/project_controller.js
@@ -408,19 +408,23 @@ class ProjectController {
     const workspaceScript = FactoryUtils.generateXmlAsJsFile(workspace, 'WORKSPACE');
     fileInfo['workspace'] = workspaceScript;
 
+    let customInjectInfo = Object.create(null);
+    customInjectInfo.toolboxName = toolboxName;
+    customInjectInfo.div = div;
+    customInjectInfo.workspaceName = workspaceName;
     const injectScript = this.tree.appController.editorController.
         workspaceController.generateInjectFile(
-          workspace.config, div, toolboxName);
+          workspace.config, customInjectInfo);
     fileInfo['inject'] = injectScript;
 
     const blockDefScript = this.tree.appController.editorController.
         blockEditorController.getLibraryJsFile();
     fileInfo['blocks'] = blockDefScript;
 
-    return ProjectController.generateInjectFileContents(fileInfo);
+    return this.generateInjectFileContents(fileInfo);
   }
 
-  static generateInjectFileContents(object) {
+  generateInjectFileContents(object) {
     const toolboxScript = object.toolbox || '';
     const workspaceScript = object.workspace || '';
     const blockDefScript = object.blocks || '';
@@ -428,7 +432,7 @@ class ProjectController {
     let fileContents = `
 <html>
 <head>
-  <title>Starter Application</title>
+  <title>Sample Application: ${this.project.name}</title>
   <!-- Necessary Blockly Imports -->
   <script src="blockly_compressed.js"></script>
   <script src="blocks_compressed.js"></script>
@@ -448,7 +452,7 @@ class ProjectController {
   <script>${injectScript}</script>
 </head>
 <body>
-  <h1>My Blockly Application</h1>
+  <h1>My Blockly Application: ${this.project.name}</h1>
   <div id="blocklyWorkspace" style="width:80%; min-width:200px; height:60%; min-height:300px;">
     <!-- Your workspace will be auto-injected here. Make sure the ID of this div
          matches the ID specified in your inject function. -->

--- a/src/controller/project_controller.js
+++ b/src/controller/project_controller.js
@@ -410,8 +410,14 @@ class ProjectController {
 
     const injectScript = this.tree.appController.editorController.
         workspaceController.generateInjectFile(
-          workspace.config, div);
-    fileInfo['injectScript'] = injectScript;
+          workspace.config, div, toolboxName);
+    fileInfo['inject'] = injectScript;
+
+    const blockDefScript = this.tree.appController.editorController.
+        blockEditorController.getLibraryJsFile();
+    fileInfo['blocks'] = blockDefScript;
+
+    return ProjectController.generateInjectFileContents(fileInfo);
   }
 
   static generateInjectFileContents(object) {
@@ -421,32 +427,36 @@ class ProjectController {
     const injectScript = object.inject || '';
     let fileContents = `
 <html>
-<title>Starter Application</title>
-<!-- Blocks -->
-<script>
-${workspaceScript}
-</script>
-<!-- Toolboxes -->
-<script>
-${toolboxScript}
-</script>
-<!-- Workspace -->
-<script>
-${workspaceScript}
-</script>
-<!-- Inject -->
-<script>
-${injectScript}
-</script>
+<head>
+  <title>Starter Application</title>
+  <!-- Necessary Blockly Imports -->
+  <script src="blockly_compressed.js"></script>
+  <script src="blocks_compressed.js"></script>
+  <script src="javascript_compressed.js"></script>
+  <script src="en.js"></script>
+  <!-- Blocks -->
+  <script>
+  ${blockDefScript}</script>
+
+  <!-- Toolboxes -->
+  <script>${toolboxScript}</script>
+
+  <!-- Workspace -->
+  <script>${workspaceScript}</script>
+
+  <!-- Inject -->
+  <script>${injectScript}</script>
+</head>
 <body>
   <h1>My Blockly Application</h1>
-  <div id="blocklyWorkspace">
+  <div id="blocklyWorkspace" style="width:80%; min-width:200px; height:60%; min-height:300px;">
     <!-- Your workspace will be auto-injected here. Make sure the ID of this div
          matches the ID specified in your inject function. -->
   </div>
 </body>
 </html>
 `;
+    return fileContents;
   }
 
   /**

--- a/src/controller/project_controller.js
+++ b/src/controller/project_controller.js
@@ -398,16 +398,22 @@ class ProjectController {
     // From wfactory_generator.js:generateInjectString(toolboxXml)
     let div = 'blocklyWorkspace';
     let fileInfo = Object.create(null);
+
+    // TODO: Allow user to configure which resources to export.
+
+    // Grabs first toolbox.
     const toolboxName = Object.keys(this.project.toolboxSet.resources)[0];
     const toolbox = this.project.getToolbox(toolboxName);
     const toolboxScript = FactoryUtils.generateXmlAsJsFile(toolbox, 'TOOLBOX');
     fileInfo['toolbox'] = toolboxScript;
 
+    // Grabs first WorkspaceContents.
     const workspaceName = Object.keys(this.project.workspaceContentsSet.resources)[0];
     const workspace = this.project.getWorkspaceContents(workspaceName);
     const workspaceScript = FactoryUtils.generateXmlAsJsFile(workspace, 'WORKSPACE');
     fileInfo['workspace'] = workspaceScript;
 
+    // Grabs first WorkspaceConfiguration (from WorkspaceContents).
     let customInjectInfo = Object.create(null);
     customInjectInfo.toolboxName = toolboxName;
     customInjectInfo.div = div;
@@ -417,6 +423,7 @@ class ProjectController {
           workspace.config, customInjectInfo);
     fileInfo['inject'] = injectScript;
 
+    // Grabs all BlockDefinitions.
     const blockDefScript = this.tree.appController.editorController.
         blockEditorController.getLibraryJsFile();
     fileInfo['blocks'] = blockDefScript;
@@ -424,20 +431,29 @@ class ProjectController {
     return this.generateInjectFileContents(fileInfo);
   }
 
-  generateInjectFileContents(object) {
-    const toolboxScript = object.toolbox || '';
-    const workspaceScript = object.workspace || '';
-    const blockDefScript = object.blocks || '';
-    const injectScript = object.inject || '';
+  /**
+   * Returns file contents necessary for creating a sample working Blockly
+   * application based off of resources in the user's current project.
+   * @param {!Object} injectInfo Object which contains the scripts necessary
+   *     to load components of the application (broken down into a toolbox field,
+   *     workspace field, blocks field, and inject field). Each is loaded into
+   *     a script tag, and is necessary to load that resource into the application.
+   */
+  generateInjectFileContents(injectInfo) {
+    // TODO: Retrieve compressed files from local filesystem, not appspot link.
+    const toolboxScript = injectInfo.toolbox || '';
+    const workspaceScript = injectInfo.workspace || '';
+    const blockDefScript = injectInfo.blocks || '';
+    const injectScript = injectInfo.inject || '';
     let fileContents = `
 <html>
 <head>
   <title>Sample Application: ${this.project.name}</title>
   <!-- Necessary Blockly Imports -->
-  <script src="blockly_compressed.js"></script>
-  <script src="blocks_compressed.js"></script>
-  <script src="javascript_compressed.js"></script>
-  <script src="en.js"></script>
+  <script src="https://blockly-demo.appspot.com/static/blockly_compressed.js"></script>
+  <script src="https://blockly-demo.appspot.com/static/blocks_compressed.js"></script>
+  <script src="https://blockly-demo.appspot.com/static/javascript_compressed.js"></script>
+  <script src="https://blockly-demo.appspot.com/static/msg/js/en.js"></script>
   <!-- Blocks -->
   <script>
   ${blockDefScript}</script>

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -1038,16 +1038,7 @@ Do you want to add a ${categoryName} category to your custom toolbox?`;
     const xml = Blockly.Xml.domToPrettyText(toolbox.getExportData());
     const xmlStorageVariable = 'BLOCKLY_TOOLBOX_XML';
 
-    // XML ASSIGNMENT STRING (not to be executed)
-    let jsFromXml = `
-var ${xmlStorageVariable} = ${xmlStorageVariable} || null;
-
-/* BEGINNING ${xmlStorageVariable} ASSIGNMENT. DO NOT EDIT. USE BLOCKLY DEVTOOLS. */
-${xmlStorageVariable}['${toolbox.name}'] =
-    ${FactoryUtils.concatenateXmlString(xml)};
-/* END ${xmlStorageVariable} ASSIGNMENT. DO NOT EDIT. */
-`;
-      return jsFromXml;
+    return FactoryUtils.generateXmlAsJsFile(toolbox, 'TOOLBOX');
   }
 
   /**

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -47,7 +47,7 @@ class WorkspaceController extends ShadowController {
     super(projectController, hiddenWorkspace);
 
     // Creates first workspace contents and config to add to project.
-    const wsContents = this.projectController.createWorkspaceContents('WSContents');
+    // const wsContents = this.projectController.createWorkspaceContents('WSContents');
     // const wsConfig = this.projectController.createWorkspaceConfiguration('WSConfig');
 
     /**
@@ -428,7 +428,7 @@ class WorkspaceController extends ShadowController {
 
     // Set basic options.
     document.getElementById('option_css_checkbox').checked =
-        optionsObj['css'] || false;
+        optionsObj['css'] || true;
     document.getElementById('option_media_text').value =
         optionsObj['media'] || 'https://blockly-demo.appspot.com/static/media/';
     document.getElementById('option_rtl_checkbox').checked =
@@ -436,7 +436,7 @@ class WorkspaceController extends ShadowController {
     document.getElementById('option_sounds_checkbox').checked =
         optionsObj['sounds'] || false;
     document.getElementById('option_oneBasedIndex_checkbox').checked =
-        optionsObj['oneBasedIndex'] || false;
+        optionsObj['oneBasedIndex'] || true;
     document.getElementById('option_horizontalLayout_checkbox').checked =
         optionsObj['horizontalLayout'] || false;
     document.getElementById('option_toolboxPosition_checkbox').checked =
@@ -609,18 +609,27 @@ class WorkspaceController extends ShadowController {
    * sample Blockly app.
    * @param {!WorkspaceConfiguration} workspaceConfig The workspace configuration
    *     which will contains the options for the inject call.
-   * @param {string=} opt_div ID of div element to inject Blockly workspace.
-   *     Inserts placeholder comment if no div is given.
-   * @param {string=} opt_toolboxName Name of toolbox to reference in workspace
-   *     options. Inserts placeholder comment if no toolbox name is given.
+   * @param {Object=} opt_custom Object which contains custom names for a given
+   *     Blockly application. May contain a field such as toolboxName, for the
+   *     name of the toolbox to render.
    * @return {string} String representation of starter code for injecting.
    */
-  generateInjectFile(workspaceConfig, opt_div, opt_toolboxName) {
+  generateInjectFile(workspaceConfig, opt_custom) {
     // REFACTORED from wfactory_generator.js
+    let div = 'null';
+    let toolboxName =  '/* TODO: Insert name of toolbox to display here */'
+    if (opt_custom) {
+      div = opt_custom['div'] ? `"${opt_custom['div']}"` : div;
+      toolboxName = opt_custom['toolboxName'] ? `"${opt_custom['toolboxName']}"` : toolboxName;
+    }
+    let workspaceScript = '\n';
+    if (opt_custom['workspaceName']) {
+      workspaceScript = `var workspaceContents = Blockly.Xml.textToDom(BLOCKLY_WORKSPACE_XML["${opt_custom['workspaceName']}"]);
+  Blockly.Xml.domToWorkspace(workspaceContents, workspace);`;
+    }
+
+    delete workspaceConfig.options['toolbox'];
     let attributes = this.stringifyOptions_(workspaceConfig.options, '\t');
-    let div = opt_div ? `'${opt_div}'` : 'null';
-    let toolboxName = opt_toolboxName ? `'${opt_toolboxName}'` : '/* TODO: Insert ' +
-        'name of toolbox to display here */';
     if (!workspaceConfig.options['readOnly']) {
       attributes = 'toolbox : BLOCKLY_TOOLBOX_XML[' + toolboxName +
         '], \n' + attributes;
@@ -636,6 +645,7 @@ window.onload = function() {
   /* Inject your workspace */
   /* TODO: Add or edit ID of div to inject Blockly into. */
   var workspace = Blockly.inject(${div}, BLOCKLY_OPTIONS);
+  ${workspaceScript}
 };
 `;
     return finalStr;

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -609,26 +609,28 @@ class WorkspaceController extends ShadowController {
    * sample Blockly app.
    * @param {!WorkspaceConfiguration} workspaceConfig The workspace configuration
    *     which will contains the options for the inject call.
+   * @param {string=} opt_div ID of div element to inject Blockly workspace.
    * @return {string} String representation of starter code for injecting.
    */
-  generateInjectFile(workspaceConfig) {
+  generateInjectFile(workspaceConfig, opt_div) {
     // REFACTORED from wfactory_generator.js
-    var attributes = this.stringifyOptions_(workspaceConfig.options, '\t');
+    let attributes = this.stringifyOptions_(workspaceConfig.options, '\t');
+    let div = opt_div ? `'${opt_div}'` : 'null';
     if (!workspaceConfig.options['readOnly']) {
       attributes = 'toolbox : BLOCKLY_TOOLBOX_XML[/* TODO: Insert name of ' +
         'imported toolbox to display here */], \n' + attributes;
     }
 
     // Initializing toolbox
-    var finalStr = `
+    let finalStr = `
 var BLOCKLY_OPTIONS = {
   ${attributes}
 };
 
 document.onload = function() {
   /* Inject your workspace */
-  /* TODO: Add ID of div to inject Blockly into */
-  var workspace = Blockly.inject(null, BLOCKLY_OPTIONS);
+  /* TODO: Add or edit ID of div to inject Blockly into. */
+  var workspace = Blockly.inject(${div}, BLOCKLY_OPTIONS);
 };
 `;
     return finalStr;

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -46,10 +46,6 @@ class WorkspaceController extends ShadowController {
   constructor(projectController, hiddenWorkspace) {
     super(projectController, hiddenWorkspace);
 
-    // Creates first workspace contents and config to add to project.
-    // const wsContents = this.projectController.createWorkspaceContents('WSContents');
-    // const wsConfig = this.projectController.createWorkspaceConfiguration('WSConfig');
-
     /**
      * WorkspaceEditorView associated with this instance of WorkspaceController.
      * @type {!WorkspaceEditorView}

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -48,7 +48,7 @@ class WorkspaceController extends ShadowController {
 
     // Creates first workspace contents and config to add to project.
     const wsContents = this.projectController.createWorkspaceContents('WSContents');
-    const wsConfig = this.projectController.createWorkspaceConfiguration('WSConfig');
+    // const wsConfig = this.projectController.createWorkspaceConfiguration('WSConfig');
 
     /**
      * WorkspaceEditorView associated with this instance of WorkspaceController.
@@ -157,7 +157,7 @@ class WorkspaceController extends ShadowController {
    * Saves blocks on editor workspace into the WorkspaceContents model.
    */
   saveStateFromWorkspace() {
-    this.view.getWorkspaceContents.setXml(this.generateContentsXml());
+    this.view.getWorkspaceContents().setXml(this.generateContentsXml());
   }
 
   /**
@@ -610,15 +610,20 @@ class WorkspaceController extends ShadowController {
    * @param {!WorkspaceConfiguration} workspaceConfig The workspace configuration
    *     which will contains the options for the inject call.
    * @param {string=} opt_div ID of div element to inject Blockly workspace.
+   *     Inserts placeholder comment if no div is given.
+   * @param {string=} opt_toolboxName Name of toolbox to reference in workspace
+   *     options. Inserts placeholder comment if no toolbox name is given.
    * @return {string} String representation of starter code for injecting.
    */
-  generateInjectFile(workspaceConfig, opt_div) {
+  generateInjectFile(workspaceConfig, opt_div, opt_toolboxName) {
     // REFACTORED from wfactory_generator.js
     let attributes = this.stringifyOptions_(workspaceConfig.options, '\t');
     let div = opt_div ? `'${opt_div}'` : 'null';
+    let toolboxName = opt_toolboxName ? `'${opt_toolboxName}'` : '/* TODO: Insert ' +
+        'name of toolbox to display here */';
     if (!workspaceConfig.options['readOnly']) {
-      attributes = 'toolbox : BLOCKLY_TOOLBOX_XML[/* TODO: Insert name of ' +
-        'imported toolbox to display here */], \n' + attributes;
+      attributes = 'toolbox : BLOCKLY_TOOLBOX_XML[' + toolboxName +
+        '], \n' + attributes;
     }
 
     // Initializing toolbox
@@ -627,7 +632,7 @@ var BLOCKLY_OPTIONS = {
   ${attributes}
 };
 
-document.onload = function() {
+window.onload = function() {
   /* Inject your workspace */
   /* TODO: Add or edit ID of div to inject Blockly into. */
   var workspace = Blockly.inject(${div}, BLOCKLY_OPTIONS);

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -56,7 +56,9 @@ FactoryUtils.getBlockDefinition = function(format, workspace) {
  * @return {string} Block definition.
  */
 FactoryUtils.getBlockDefFromXml = function(format, rootXml, workspace) {
+  console.log(rootXml);
   var rootBlock = Blockly.Xml.domToBlock(rootXml, workspace);
+  console.log(rootBlock);
   return FactoryUtils.getBlockDefFromRoot_(format, rootBlock, workspace);
 };
 
@@ -66,9 +68,11 @@ FactoryUtils.getBlockDefFromXml = function(format, rootXml, workspace) {
  * @param {!Blockly.Block} rootBlock The root block displayed on editor workspace.
  * @param {!Blockly.Workspace} workspace Where the root block is from.
  * @return {string} Block definition.
+ * @private
  */
 FactoryUtils.getBlockDefFromRoot_ = function(format, rootBlock, workspace) {
   const blockType = FactoryUtils.cleanBlockType(rootBlock.getFieldValue('NAME'));
+  console.log('blockType: ' + blockType);
   switch (format) {
     case 'JSON':
       var code = FactoryUtils.formatJson_(blockType, rootBlock);
@@ -380,7 +384,9 @@ FactoryUtils.formatJavaScript_ = function(blockType, rootBlock, workspace) {
   code.push(' this.setHelpUrl(' + JSON.stringify(helpUrl) + ');');
   code.push('  }');
   code.push('};');
-  return code.join('\n');
+  const definition = code.join('\n');
+  console.log(definition);
+  return definition;
 };
 
 /**

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -383,9 +383,7 @@ FactoryUtils.formatJavaScript_ = function(blockType, rootBlock, workspace) {
   code.push(' this.setHelpUrl(' + JSON.stringify(helpUrl) + ');');
   code.push('  }');
   code.push('};');
-  const definition = code.join('\n');
-  console.log(definition);
-  return definition;
+  return code.join('\n');
 };
 
 /**

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -56,9 +56,7 @@ FactoryUtils.getBlockDefinition = function(format, workspace) {
  * @return {string} Block definition.
  */
 FactoryUtils.getBlockDefFromXml = function(format, rootXml, workspace) {
-  console.log(rootXml);
   var rootBlock = Blockly.Xml.domToBlock(rootXml, workspace);
-  console.log(rootBlock);
   return FactoryUtils.getBlockDefFromRoot_(format, rootBlock, workspace);
 };
 
@@ -72,7 +70,6 @@ FactoryUtils.getBlockDefFromXml = function(format, rootXml, workspace) {
  */
 FactoryUtils.getBlockDefFromRoot_ = function(format, rootBlock, workspace) {
   const blockType = FactoryUtils.cleanBlockType(rootBlock.getFieldValue('NAME'));
-  console.log('blockType: ' + blockType);
   switch (format) {
     case 'JSON':
       var code = FactoryUtils.formatJson_(blockType, rootBlock);

--- a/src/model/block_library_set.js
+++ b/src/model/block_library_set.js
@@ -40,16 +40,28 @@ class BlockLibrarySet extends ResourceSet {
   }
 
   /**
-   * Returns a map of all block types in the library set to their definitions.
-   * @return {!Object<string, BlockDefinition>} Map of all block types to their
-   *     definitions.
+   * Returns an array of all block types in the library set.
+   * @return {!Array<string>} Array of all block names.
    */
-  getAllBlockDefinitionsMap() {
+  getAllBlockTypes() {
     let allBlockTypes = [];
     for (let blockLib in this.resources) {
       allBlockTypes = allBlockTypes.concat(this.resources[blockLib].getBlockTypes());
     }
     return allBlockTypes;
+  }
+
+  /**
+   * Returns a map of all block types in the library set to their definitions.
+   * @return {!Object<string, BlockDefinition>} Map of all block types to their
+   *     definitions.
+   */
+  getAllBlockDefinitionsMap() {
+    let allBlockDefs = Object.create(null);
+    for (let blockLib in this.resources) {
+      allBlockDefs = Object.assign(allBlockDefs, this.resources[blockLib].blocks);
+    }
+    return allBlockDefs;
   }
 
   /**

--- a/src/model/project.js
+++ b/src/model/project.js
@@ -73,7 +73,7 @@ class Project extends Resource {
    * @return {!Array.<string>} Array of all block types in the project.
    */
   getBlockTypes() {
-    return this.librarySet.getAllBlockDefinitionsMap();
+    return this.librarySet.getAllBlockTypes();
   }
 
   /**

--- a/src/model/workspace_configuration.js
+++ b/src/model/workspace_configuration.js
@@ -41,7 +41,7 @@ class WorkspaceConfiguration extends Resource {
      /**
       * Options object to be configured for Blockly inject call.
       */
-     this.options = Object.create(null);
+    this.options = Object.create(null);
   }
 
   /**

--- a/src/view/app_view.js
+++ b/src/view/app_view.js
@@ -241,7 +241,7 @@ class AppView {
    * Action taken when creating sample Blockly web application.
    */
   createWeb() {
-    // TODO: Fill in action.
+    this.appController.saveSampleApplication('WEB');
   }
 
   /**

--- a/src/view/app_view.js
+++ b/src/view/app_view.js
@@ -236,7 +236,7 @@ class AppView {
    * Action taken when creating sample Blockly web application.
    */
   createWeb() {
-    this.appController.saveSampleApplication('WEB');
+    this.appController.saveSampleApplication();
   }
 
   /**


### PR DESCRIPTION
Very hard-coded (but tried to make it easily extendable) -- upon exporting as sample blockly application, user is prompted to download an html file which loads the first toolbox and first workspace contents/config. 

Retrieves compressed files from appspot link.

(Will follow up with using fs/node to use locally downloaded compressed files).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/218)
<!-- Reviewable:end -->
