### PR TITLE
[Bugfix] Cleaning Up Model Duplicates

### DIFF
--- a/app.html
+++ b/app.html
@@ -9,10 +9,6 @@
     window.addEventListener('load', () => {
       DevTools = new AppController();
       window.addEventListener('beforeunload', DevTools.confirmLeavePage);
-      // Generate new project popup.
-      // Uncomment line below to enable project popup on load.
-      // DevTools.createPopup(PopupController.NEW_PROJECT);
-      DevTools.initProject('MyProject');
     });
   </script>
 </head>

--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -43,9 +43,6 @@ class ToolboxController extends ShadowController {
   constructor(projectController, hiddenWorkspace) {
     super(projectController, hiddenWorkspace);
 
-    // Creates first toolbox to add to project.
-    const toolbox = this.projectController.createToolbox('MyFirstToolbox');
-
     /**
      * ToolboxEditorView associated with this instance of ToolboxController.
      * @type {!ToolboxEditorView}


### PR DESCRIPTION
Event listeners and view components (navtree) were being created twice because AppController's `initProject()` function was called twice--once in `app.html` and again at the end of AppController's constructor.

Also removed extra toolbox created within ToolboxController's constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/234)
<!-- Reviewable:end -->
