### PR TITLE
Workspace Editor: Splitting Contents and Config

### DIFF
--- a/app.html
+++ b/app.html
@@ -36,7 +36,8 @@
       <div id="addBlock">Block</div>
       <div id="addLibrary">Library</div>
       <div id="addToolbox">Toolbox</div>
-      <div id="addWorkspaceContents">Workspace</div>
+      <div id="addWorkspaceContents">Workspace Contents</div>
+      <div id="addWorkspaceConfig">Workspace Configuration</div>
     </div>
 </div>
 </body>

--- a/src/controller/app_controller.js
+++ b/src/controller/app_controller.js
@@ -288,6 +288,7 @@ class AppController {
     }
     projController.createToolbox('MyFirstToolbox');
     projController.createWorkspaceContents('MyFirstWorkspace');
+    projController.createWorkspaceConfiguration('MyFirstConfig');
     projController.createBlockLibrary('MyFirstBlockLibrary');
     this.editorController.blockEditorController.createNewBlock(
         '', 'myFirstBlock', 'MyFirstBlockLibrary', 'My Block');
@@ -395,7 +396,8 @@ class AppController {
    * and model.
    */
   createWorkspaceContents() {
-    let name = this.getResourceName_(PREFIXES.WORKSPACE_CONTENTS, 'Workspace');
+    let name = this.getResourceName_(
+        PREFIXES.WORKSPACE_CONTENTS, 'WorkspaceContents');
     if (name) {
       const workspaceContents =
           this.projectController.createWorkspaceContents(name);
@@ -408,7 +410,8 @@ class AppController {
    * editors, and model.
    */
   createWorkspaceConfiguration() {
-    let name = this.getResourceName_(PREFIXES.WORKSPACE_CONFIG);
+    let name = this.getResourceName_(
+        PREFIXES.WORKSPACE_CONFIG, 'WorkspaceConfig');
     if (name) {
       const workspaceConfig = this.projectController.createWorkspaceConfiguration(name);
       this.switchEnvironment(AppController.WORKSPACE_EDITOR, workspaceConfig);

--- a/src/controller/editor_controller.js
+++ b/src/controller/editor_controller.js
@@ -99,7 +99,7 @@ class EditorController {
       this.currentEditor.updateEditorToolbox();
     } else if (editor instanceof WorkspaceController) {
       this.currentEditor.loadContents(this.currentEditor.view.getWorkspaceContents());
-      this.currentEditor.loadConfig(this.currentEditor.view.getWorkspaceContents().config);
+      this.currentEditor.loadConfig(this.currentEditor.view.workspaceConfig);
       this.currentEditor.setResource(this.currentEditor.view.getWorkspaceContents());
       this.currentEditor.updateEditorToolbox();
     }

--- a/src/controller/project_controller.js
+++ b/src/controller/project_controller.js
@@ -413,14 +413,15 @@ class ProjectController {
     const workspaceScript = FactoryUtils.generateXmlAsJsFile(workspace, 'WORKSPACE');
     fileInfo['workspace'] = workspaceScript;
 
-    // Grabs first WorkspaceConfiguration (from WorkspaceContents).
+    // Grabs first WorkspaceConfiguration.
+    const configName = Object.keys(this.project.workspaceConfigSet.resources)[0];
+    const config = this.project.getWorkspaceConfiguration(configName);
     let customInjectInfo = Object.create(null);
     customInjectInfo.toolboxName = toolboxName;
     customInjectInfo.div = div;
     customInjectInfo.workspaceName = workspaceName;
     const injectScript = this.tree.appController.editorController.
-        workspaceController.generateInjectFile(
-          workspace.config, customInjectInfo);
+        workspaceController.generateInjectFile(config, customInjectInfo);
     fileInfo['inject'] = injectScript;
 
     // Grabs all BlockDefinitions.

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -217,6 +217,8 @@ class WorkspaceController extends ShadowController {
         this.view.editorWorkspace);
     this.view.editorWorkspace.cleanUp();
     this.updatePreview();
+    // TODO(#226): Split contents/config view into two separate views and remove
+    // code below (disables part of editor).
     if (this.view.current instanceof WorkspaceConfiguration) {
       FactoryUtils.disableEdits(true, 'wsContentsDiv');
     } else {
@@ -237,6 +239,8 @@ class WorkspaceController extends ShadowController {
     const options = wsConfig ? wsConfig.options : Object.create(null);
     this.writeOptions_(options);
     this.updateOptions();
+    // TODO(#226): Split contents/config view into two separate views and remove
+    // code below (disables part of editor).
     if (this.view.current instanceof WorkspaceContents) {
       FactoryUtils.disableEdits(true, 'preload_div');
     } else {

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -91,7 +91,7 @@ class WorkspaceController extends ShadowController {
   reinjectPreview() {
     // From wfactory_controller.js:reinjectPreview(tree)
     this.view.previewWorkspace.dispose();
-    const injectOptions = this.view.getWorkspaceContents().config.options;
+    const injectOptions = this.view.workspaceConfig.options;
     injectOptions['toolbox'] = '<xml></xml>';
 
     this.view.previewWorkspace = Blockly.inject('workspacePreview', injectOptions);
@@ -212,12 +212,12 @@ class WorkspaceController extends ShadowController {
           'Cannot load an undefined or null WorkspaceContents onto workspace.');
       return;
     }
+    this.view.editorWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.view.getWorkspaceContents().getExportData(),
         this.view.editorWorkspace);
     this.view.editorWorkspace.cleanUp();
     this.updatePreview();
     if (this.view.current instanceof WorkspaceConfiguration) {
-      console.log('Disabling workspace');
       FactoryUtils.disableEdits(true,
           'workspace_section', 'wsContentsDiv');
     } else {
@@ -323,7 +323,7 @@ class WorkspaceController extends ShadowController {
   updateOptions() {
     // From wfactory_controller.js:generateNewOptions()
     // TODO (#141): Add popup for workspace config.
-    this.view.getWorkspaceContents().config.setOptions(this.readOptions_());
+    this.view.workspaceConfig.setOptions(this.readOptions_());
     this.reinjectPreview();
   }
 
@@ -477,10 +477,11 @@ class WorkspaceController extends ShadowController {
 
     // Set zoom options.
     let zoom = optionsObj['zoom'] || Object.create(null);
+    let hasZoom = zoom.startScale ? true : false;
     document.getElementById('option_zoom_checkbox').checked =
-        zoom ? true : false;
+        hasZoom ? true : false;
     document.getElementById('zoom_options').style.display =
-        zoom ? 'block' : 'none';
+        hasZoom ? 'block' : 'none';
     document.getElementById('zoomOption_controls_checkbox').checked =
         zoom['controls'] || true;
     document.getElementById('zoomOption_wheel_checkbox').checked =

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -216,6 +216,14 @@ class WorkspaceController extends ShadowController {
         this.view.editorWorkspace);
     this.view.editorWorkspace.cleanUp();
     this.updatePreview();
+    if (this.view.current instanceof WorkspaceConfiguration) {
+      console.log('Disabling workspace');
+      FactoryUtils.disableEdits(true,
+          'workspace_section', 'wsContentsDiv');
+    } else {
+      FactoryUtils.disableEdits(false,
+          'workspace_section', 'wsContentsDiv');
+    }
   }
 
   /**
@@ -231,6 +239,11 @@ class WorkspaceController extends ShadowController {
     const options = wsConfig ? wsConfig.options : Object.create(null);
     this.writeOptions_(options);
     this.updateOptions();
+    if (this.view.current instanceof WorkspaceContents) {
+      FactoryUtils.disableEdits(true, 'preload_div');
+    } else {
+      FactoryUtils.disableEdits(false, 'preload_div');
+    }
   }
 
   /**

--- a/src/controller/workspace_controller.js
+++ b/src/controller/workspace_controller.js
@@ -218,11 +218,9 @@ class WorkspaceController extends ShadowController {
     this.view.editorWorkspace.cleanUp();
     this.updatePreview();
     if (this.view.current instanceof WorkspaceConfiguration) {
-      FactoryUtils.disableEdits(true,
-          'workspace_section', 'wsContentsDiv');
+      FactoryUtils.disableEdits(true, 'wsContentsDiv');
     } else {
-      FactoryUtils.disableEdits(false,
-          'workspace_section', 'wsContentsDiv');
+      FactoryUtils.disableEdits(false, 'wsContentsDiv');
     }
   }
 

--- a/src/factory.css
+++ b/src/factory.css
@@ -262,7 +262,7 @@ button, .buttonStyle {
 
 #toolboxEditor, #workspaceEditor {
   clear: both;
-  height: 90%;
+  height: 100%;
   overflow-x: hidden;
   overflow-y: scroll;
 }

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -1397,3 +1397,22 @@ FactoryUtils.cleanResourceName = function(resourceName) {
   // TODO(#166): Clean names of resources (given by users) to minimize errors.
   return resourceName;
 };
+
+/**
+ * Disables or enables some editable component of application. Can be a Blockly
+ * Workspace or checkbox form for WorkspaceConfiguration. Puts a div over or under
+ * the editor area, depending on the value of disable.
+ * @param {boolean} disable Whether to disable the component. If false, enables.
+ * @param {string} sectionId ID of the section which contains the component to
+ *     enable or disable.
+ * @param {string=} opt_injectId Param used when disabling a Blockly workspace.
+ *     ID of the div into which the Blockly workspace was injected.
+ */
+FactoryUtils.disableEdits = function(disable, sectionId, opt_injectId) {
+  const section = document.getElementById(sectionId);
+  opt_injectId = opt_injectId || sectionId;
+  const injectDiv = document.getElementById(opt_injectId);
+
+  section.className = disable ? 'disabled' : '';
+  section.style.pointerEvents = disable ? 'none' : 'auto';
+};

--- a/src/factory_utils.js
+++ b/src/factory_utils.js
@@ -1405,13 +1405,9 @@ FactoryUtils.cleanResourceName = function(resourceName) {
  * @param {boolean} disable Whether to disable the component. If false, enables.
  * @param {string} sectionId ID of the section which contains the component to
  *     enable or disable.
- * @param {string=} opt_injectId Param used when disabling a Blockly workspace.
- *     ID of the div into which the Blockly workspace was injected.
  */
-FactoryUtils.disableEdits = function(disable, sectionId, opt_injectId) {
+FactoryUtils.disableEdits = function(disable, sectionId) {
   const section = document.getElementById(sectionId);
-  opt_injectId = opt_injectId || sectionId;
-  const injectDiv = document.getElementById(opt_injectId);
 
   section.className = disable ? 'disabled' : '';
   section.style.pointerEvents = disable ? 'none' : 'auto';

--- a/src/model/project.js
+++ b/src/model/project.js
@@ -280,7 +280,8 @@ class Project extends Resource {
       { 'id': PREFIXES.PROJECT, 'text': this.name,
         'children': [ this.librarySet.getNavTreeJson(),
           this.toolboxSet.getNavTreeJson(),
-          this.workspaceContentsSet.getNavTreeJson()]}
+          this.workspaceContentsSet.getNavTreeJson(),
+          this.workspaceConfigSet.getNavTreeJson()]}
     );
     return projectJson;
   }

--- a/src/model/workspace_configuration_set.js
+++ b/src/model/workspace_configuration_set.js
@@ -38,4 +38,19 @@ class WorkspaceConfigurationSet extends ResourceSet {
   constructor(workspaceConfigurationSetName, projectName) {
     super(workspaceConfigurationSetName, projectName);
   }
+
+  /**
+   * Produces the navigation tree-spcific JSON that represents the workspace
+   * configuration set.
+   * @return {!Object} The JSON for workspace configuration set.
+   */
+  // TODO(#219): Move this code to NavigationTree
+  getNavTreeJson() {
+    const workspaceConfigSetJson = {
+      'id': PREFIXES.WORKSPACE_CONFIG,
+      'text': 'Workspace Configuration',
+      'children': super.getNavTreeJson()
+    };
+    return workspaceConfigSetJson;
+  }
 }

--- a/src/model/workspace_contents.js
+++ b/src/model/workspace_contents.js
@@ -38,9 +38,6 @@ class WorkspaceContents extends Resource {
   constructor(workspaceContentsName) {
     super(workspaceContentsName, PREFIXES.WORKSPACE_CONTENTS);
 
-    // TODO(#201): Create wrapper class for contents and config object instead
-    // of having a config field within contents.
-
     /**
      * XML DOM element of this workspace contents.
      * @type {!Element}

--- a/src/model/workspace_contents.js
+++ b/src/model/workspace_contents.js
@@ -38,6 +38,9 @@ class WorkspaceContents extends Resource {
   constructor(workspaceContentsName) {
     super(workspaceContentsName, PREFIXES.WORKSPACE_CONTENTS);
 
+    // TODO(#201): Create wrapper class for contents and config object instead
+    // of having a config field within contents.
+
     /**
      * XML DOM element of this workspace contents.
      * @type {!Element}
@@ -49,10 +52,6 @@ class WorkspaceContents extends Resource {
      * @type {!Array.<string>}
      */
     this.shadowBlocks = [];
-
-    // TODO(#201): Create wrapper class for contents and config object instead
-    // of having a config field within contents.
-    this.config = new WorkspaceConfiguration(this.name);
   }
 
   /**

--- a/src/model/workspace_contents_set.js
+++ b/src/model/workspace_contents_set.js
@@ -56,7 +56,7 @@ class WorkspaceContentsSet extends ResourceSet {
   getNavTreeJson() {
     const workspaceContentsSetJson = {
       'id': PREFIXES.WORKSPACE_CONTENTS,
-      'text': 'Workspaces',
+      'text': 'Workspace Contents',
       'children': super.getNavTreeJson()
     };
     return workspaceContentsSetJson;

--- a/src/view/navigation_tree.js
+++ b/src/view/navigation_tree.js
@@ -137,7 +137,6 @@ class NavigationTree {
    */
   makeTree_() {
     const treeJson = this.makeTreeJson();
-    console.log(treeJson);
     this.makeTreeListener_();
     $('#navigationTree').jstree(treeJson);
   }

--- a/src/view/navigation_tree.js
+++ b/src/view/navigation_tree.js
@@ -137,6 +137,7 @@ class NavigationTree {
    */
   makeTree_() {
     const treeJson = this.makeTreeJson();
+    console.log(treeJson);
     this.makeTreeListener_();
     $('#navigationTree').jstree(treeJson);
   }

--- a/src/view/toolbox_editor_view.js
+++ b/src/view/toolbox_editor_view.js
@@ -432,7 +432,6 @@ class ToolboxEditorView {
    * @param {ListElement} selected The selected ListElement.
    */
   updateState(selectedIndex, selected) {
-    // From
     // Disable/enable editing buttons as necessary.
     this.editButton.disabled = selectedIndex < 0 ||
         selected.type != ListElement.TYPE_CATEGORY;
@@ -442,26 +441,8 @@ class ToolboxEditorView {
     this.downButton.disabled = selectedIndex >=
         table.rows.length - 1 || selectedIndex < 0;
     // Disable/enable the workspace as necessary.
-    this.disableWorkspace(this.shouldDisableWorkspace(selected));
-  }
-
-  /**
-   * Disables or enables the workspace by putting a div over or under the
-   * toolbox workspace, depending on the value of disable. Used when switching
-   * to/from separators where the user shouldn't be able to drag blocks into
-   * the workspace.
-   * @param {boolean} disable True if the workspace should be disabled, false
-   *     if it should be enabled.
-   */
-  disableWorkspace(disable) {
-    // From wfactory_view.js:disableWorkspace(disable)
-    if (disable) {
-      document.getElementById('toolbox_section').className = 'disabled';
-      document.getElementById('toolboxDiv').style.pointerEvents = 'none';
-    } else {
-      document.getElementById('toolbox_section').className = '';
-      document.getElementById('toolboxDiv').style.pointerEvents = 'auto';
-    }
+    FactoryUtils.disableEdits(this.shouldDisableWorkspace(selected),
+        'toolbox_section', 'toolboxDiv');
   }
 
   /**

--- a/src/view/workspace_editor_view.js
+++ b/src/view/workspace_editor_view.js
@@ -51,9 +51,18 @@ class WorkspaceEditorView {
 
     /**
      * WorkspaceConfig associated with this instance of WorkspaceView.
-     * @type {!WorkspaceConfig}
+     * @type {!WorkspaceConfiguration}
      */
-    // this.workspaceConfig = workspaceConfig;
+    this.workspaceConfig = workspaceConfig;
+
+    /**
+     * Resource object which is currently being edited in the Workspace view.
+     * Used to differentiate between whether a user has loaded the workspace
+     * view by clicking on a contents or configuration object. (If one, the
+     * other should not be editable).
+     * @type {!WorkspaceContents|!WorkspaceConfiguration}
+     */
+    this.current = null;
 
     /**
      * JQuery container of workspace editor view.
@@ -174,10 +183,12 @@ class WorkspaceEditorView {
       this.workspaceContents_ = wsElement;
       this.refreshWorkspaceInfo();
       this.selectedBlock = null;
+      this.current = wsElement;
     } else if (wsElement instanceof WorkspaceConfiguration) {
-      throw 'Loading only WorkspaceConfiguration objects is not supported. Config ' +
-          'objects are now a field of WorkspaceContents objects.';
+      this.current = wsElement;
+      this.workspaceConfig = wsElement;
     }
+    console.log(this.current);
   }
 
   /**
@@ -427,12 +438,12 @@ WorkspaceEditorView.html = `
     <h3>Edit Workspace elements</h3>
     <p id="editHelpText">Drag blocks into the workspace to configure your custom workspace.</p>
   </div>
+    <p><b>Current workspace:</b> <span id="currentWorkspace"></span></p>
   <section id="workspace_section">
-    <div style="float: right">
+    <aside>
       <button id="button_addShadowWorkspace" style="display: none">Make Shadow</button>
       <button id="button_removeShadowWorkspace" style="display: none">Remove Shadow</button>
-    </div>
-    <p><b>Current workspace:</b> <span id="currentWorkspace"></span></p>
+    </aside>
     <div id="wsContentsDiv" style="clear: both"></div>
   </section>
 

--- a/src/view/workspace_editor_view.js
+++ b/src/view/workspace_editor_view.js
@@ -179,7 +179,6 @@ class WorkspaceEditorView {
       throw 'Workspace element is null or undefined.';
       return;
     } else if (wsElement instanceof WorkspaceContents) {
-      this.editorWorkspace.clear();
       this.workspaceContents_ = wsElement;
       this.refreshWorkspaceInfo();
       this.selectedBlock = null;
@@ -188,7 +187,6 @@ class WorkspaceEditorView {
       this.current = wsElement;
       this.workspaceConfig = wsElement;
     }
-    console.log(this.current);
   }
 
   /**

--- a/src/view/workspace_editor_view.js
+++ b/src/view/workspace_editor_view.js
@@ -419,6 +419,7 @@ class WorkspaceEditorView {
    * model object.
    */
   refreshWorkspaceInfo() {
+    // TODO(#226): Split contents/config into two separate views.
     if (this.current instanceof WorkspaceContents) {
       $('#workspace_component').text('contents');
       $('#current_workspace').text(this.current.name);

--- a/src/view/workspace_editor_view.js
+++ b/src/view/workspace_editor_view.js
@@ -180,13 +180,13 @@ class WorkspaceEditorView {
       return;
     } else if (wsElement instanceof WorkspaceContents) {
       this.workspaceContents_ = wsElement;
-      this.refreshWorkspaceInfo();
       this.selectedBlock = null;
-      this.current = wsElement;
     } else if (wsElement instanceof WorkspaceConfiguration) {
-      this.current = wsElement;
       this.workspaceConfig = wsElement;
     }
+
+    this.current = wsElement;
+    this.refreshWorkspaceInfo();
   }
 
   /**
@@ -419,8 +419,12 @@ class WorkspaceEditorView {
    * model object.
    */
   refreshWorkspaceInfo() {
-    if (!this.getWorkspaceContents()) {
-      $('#currentWorkspace').text(this.getWorkspaceContents().name);
+    if (this.current instanceof WorkspaceContents) {
+      $('#workspace_component').text('contents');
+      $('#current_workspace').text(this.current.name);
+    } else if (this.current instanceof WorkspaceConfiguration) {
+      $('#workspace_component').text('configuration');
+      $('#current_workspace').text(this.current.name);
     }
   }
 }
@@ -436,8 +440,8 @@ WorkspaceEditorView.html = `
     <h3>Edit Workspace elements</h3>
     <p id="editHelpText">Drag blocks into the workspace to configure your custom workspace.</p>
   </div>
-    <p><b>Current workspace:</b> <span id="currentWorkspace"></span></p>
   <section id="workspace_section">
+    <p><b>Current workspace <span id="workspace_component"></span>:</b> <span id="current_workspace"></span></p>
     <aside>
       <button id="button_addShadowWorkspace" style="display: none">Make Shadow</button>
       <button id="button_removeShadowWorkspace" style="display: none">Remove Shadow</button>


### PR DESCRIPTION
Workspace contents and config are now explicitly separate in devtools. Users can only edit one at a time in an editor (e.g. if a user clicks on a config object in the navtree, the contents editor will be disabled but still render a preview of the last contents object the user edited).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/236)
<!-- Reviewable:end -->
