### PR TITLE
[Bugfix #232] Toolbox Editor: Removing Categories Bugfix

### DIFF
--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -184,7 +184,7 @@ class ToolboxController extends ShadowController {
 
     // Find next logical element to switch to.
     let next = toolbox.getElementByIndex(selectedIndex);
-    if (!next && !toolbox.isEmpty()) {
+    if (!next && !toolbox.hasNoCategories()) {
       next = toolbox.getElementByIndex(selectedIndex - 1);
     }
     const nextId = next ? next.id : null;

--- a/src/model/toolbox.js
+++ b/src/model/toolbox.js
@@ -387,6 +387,18 @@ class Toolbox extends Resource {
   }
 
   /**
+   * Returns whether the toolbox does not have any categories.
+   * Will return false if there is one category in the toolbox that is not a
+   * flyout and will return true if there is one category in the toolbox that is
+   * a flyout.
+   * @return {boolean} Whether there are no categories in the toolbox.
+   */
+  hasNoCategories() {
+    return this.categoryList.length == 1 &&
+        this.categoryList[0].type == ListElement.TYPE_FLYOUT;
+  }
+
+  /**
    * Determines whether user-given category name already exists. Used when getting
    * a valid category name from the user.
    *


### PR DESCRIPTION
Fixed #232. 

Fixed possibly #252, though I'm not sure what the error message pasted into the issue is referring to. I think I reproduced the error messages in 252 on develop and couldn't do so on this branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/264)
<!-- Reviewable:end -->
