### PR TITLE
[Bugfix #173] Toolbox Editor: Showing Category Colors on Switch

### DIFF
--- a/src/controller/toolbox_controller.js
+++ b/src/controller/toolbox_controller.js
@@ -656,6 +656,8 @@ Do you want to add a ${categoryName} category to your custom toolbox?`;
         if (elem.type = ListElement.TYPE_CATEGORY) {
           // Add tab to view.
           const tab = this.view.addCategoryTab(elem.name, elem.id);
+          // Add color to tab.
+          this.view.setBorderColor(elem.id, elem.color);
           // Deselects tab that was just selected within addCategoryTab().
           this.view.selectTab(elem.id, false);
           // Adds click listener.

--- a/src/view/toolbox_editor_view.js
+++ b/src/view/toolbox_editor_view.js
@@ -601,7 +601,7 @@ class ToolboxEditorView {
   setBorderColor(id, color) {
     // From wfactory_view.js:setBorderColor(id, color)
     const tab = this.tabMap[id];
-    if (!tab) {
+    if (!tab || !color) {
       return;
     }
     tab.style.borderLeftWidth = '8px';


### PR DESCRIPTION
Fixed #173.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/265)
<!-- Reviewable:end -->
