### PR TITLE
[Bugfix #248] Duplicate error message no longer always says "toolbox"

### DIFF
--- a/src/controller/app_controller.js
+++ b/src/controller/app_controller.js
@@ -461,7 +461,7 @@ class AppController {
       isEmpty = name && name.trim() ? false : true;
       // Handles errors.
       if (isDuplicate) {
-        errorText = 'This toolbox already exists.\n';
+        errorText = 'This ' + resourceType + ' already exists.\n';
       } else if (isEmpty) {
         return null;
       }


### PR DESCRIPTION
Fixed #248.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/266)
<!-- Reviewable:end -->
