### PR TITLE
Fix: Block edits update JSON definition

### DIFF
--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -142,7 +142,7 @@ class BlockEditorController {
   refreshPreviews() {
     const format = $('#format').val();
     this.updateBlockDefinitionView_(format);
-    this.updatePreview_();
+    this.updatePreview();
     this.updateGenerator_();
   }
 
@@ -164,7 +164,7 @@ class BlockEditorController {
       const code = languagePre.text().trim();
       languageTA.val(code);
       languageTA.focus();
-      this.updatePreview_();
+      this.updatePreview();
     } else {
       mask.hide();
       languageTA.hide();
@@ -177,7 +177,6 @@ class BlockEditorController {
    * Update the block definition code based on constructs made in Blockly.
    */
   updateLanguage() {
-    // TODO: Move in from factory.js
     var rootBlock = FactoryUtils.getRootBlock(this.view.editorWorkspace);
     if (!rootBlock) {
       return;
@@ -190,7 +189,7 @@ class BlockEditorController {
     var code = FactoryUtils.getBlockDefinition(format,
         this.view.editorWorkspace);
     FactoryUtils.injectCode(code, 'languagePre');
-    this.updatePreview_();
+    this.updatePreview();
   }
 
   /**
@@ -288,9 +287,8 @@ class BlockEditorController {
 
   /**
    * Update the preview display.
-   * @private
    */
-  updatePreview_() {
+  updatePreview() {
     // REFACTORED: Moved in from factory.js:updatePreview()
     const newDir = $('#direction').val();
     this.view.updateDirection(newDir);

--- a/src/view/app_view.js
+++ b/src/view/app_view.js
@@ -492,7 +492,7 @@ class AppView {
   /**
    * Add event listeners for the block factory.
    */
-  // TODO: Move to BlockEditorView or Controller.
+  // TODO(#276): Move to BlockEditorView or Controller.
   addBlockFactoryEventListeners() {
     const controller =
         this.appController.editorController.blockEditorController;

--- a/src/view/app_view.js
+++ b/src/view/app_view.js
@@ -492,26 +492,32 @@ class AppView {
   /**
    * Add event listeners for the block factory.
    */
+  // TODO: Move to BlockEditorView or Controller.
   addBlockFactoryEventListeners() {
-    // REFACTORED: Moved in from app_controller.js
+    const controller =
+        this.appController.editorController.blockEditorController;
+    const changeFormat = controller.changeFormat.bind(controller);
+    const updateLanguage = controller.updateLanguage.bind(controller);
+    const updatePreview = controller.updatePreview.bind(controller);
+    const refreshPreviews = controller.refreshPreviews.bind(controller);
+
     // Update code on changes to block being edited.
     this.blockEditorView.editorWorkspace.addChangeListener(
-        this.appController.editorController.updateLanguage);
+        updateLanguage);
 
     // Disable blocks not attached to the factory_base block.
-    this.blockEditorView.editorWorkspace.addChangeListener(Blockly.Events.disableOrphans);
-
-    const controller = this.appController.editorController.blockEditorController;
+    this.blockEditorView.editorWorkspace.addChangeListener(
+        Blockly.Events.disableOrphans);
 
     // Update preview on every change.
     this.blockEditorView.editorWorkspace.addChangeListener(
-        controller.refreshPreviews);
+        refreshPreviews);
 
-    $('#direction').change(controller.updatePreview);
-    $('#languageTA').change(controller.updatePreview);
-    $('#languageTA').keyup(controller.updatePreview);
-    $('#format').change(controller.formatChange);
-    $('#language').change(controller.updatePreview);
+    $('#direction').change(updatePreview);
+    $('#languageTA').change(updatePreview);
+    $('#languageTA').keyup(updatePreview);
+    $('#format').change(changeFormat);
+    $('#language').change(updatePreview);
   }
 
   /**

--- a/src/view/block_editor_view.js
+++ b/src/view/block_editor_view.js
@@ -149,7 +149,7 @@ class BlockEditorView {
     // LTR <-> RTL
     $('#direction').change(() => {
       this.updateDirection($('#direction').val());
-      controller.updatePreview_();
+      controller.updatePreview();
     });
 
     // JSON <-> JS for Block Definition
@@ -159,10 +159,10 @@ class BlockEditorView {
 
     // Update preview as user manually defines block.
     $('#languageTA').on('input', () => {
-      controller.updatePreview_();
+      controller.updatePreview();
     });
     $('#languageTA').on('keyup', () => {
-      controller.updatePreview_();
+      controller.updatePreview();
     });
 
     // Update code generator


### PR DESCRIPTION
Fixes null event listeners, enabling block definition JSON to get updated properly.

First step of fixing #272.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/275)
<!-- Reviewable:end -->
