### PR TITLE
Refactor BlockDefinition to support blocks defined in JavaScript.

### DIFF
--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -99,7 +99,7 @@ class BlockEditorController {
    */
   createNewBlock(inputType, blockTypeName, libraryName, opt_blockStarterText) {
     // Creates new BlockDefinition object.
-    const newBlock = new BlockDefinition(blockTypeName);
+    const newBlock = new BlockDefinition(blockTypeName, 'JSON');
 
     // Sets XML in BlockDefinition model object.
     const starterXml = Blockly.Xml.textToDom(
@@ -143,7 +143,7 @@ class BlockEditorController {
     const format = $('#format').val();
     this.updateBlockDefinitionView_(format);
     this.updatePreview();
-    this.updateGenerator_();
+    this.updateGenerator();
   }
 
   /**
@@ -193,19 +193,18 @@ class BlockEditorController {
   }
 
   /**
-   * Updates blockType and XML of currently open BlockDefinition.
+   * Updates the BlockDefinition with the latest values from the editor.
    */
   updateBlockDefinition() {
-    const currentBlock = this.view.blockDefinition;
-    const rootBlock = FactoryUtils.getRootBlock(this.view.editorWorkspace);
-    // Sets XML field of BlockDefinition object.
-    const blockXml = '<xml>' + Blockly.Xml.domToText(Blockly.Xml.blockToDom(rootBlock)) + '</xml>';
-    currentBlock.setXml(Blockly.Xml.textToDom(blockXml));
-    // Sets JSON field of BlockDefinition object.
     // TODO(#190): Store and generate block definition JSONs more efficiently to
     // avoid repeatedly using JSON.parse().
-    currentBlock.json = FactoryUtils.getBlockDefinition(
+    const blockJson = FactoryUtils.getBlockDefinition(
           'JSON', this.view.editorWorkspace);
+
+    const rootEditorBlock = FactoryUtils.getRootBlock(this.view.editorWorkspace);
+    const blockXml = Blockly.Xml.blockToDom(rootEditorBlock);
+
+    this.view.blockDefinition.update('JSON', blockJson, blockXml);
   }
 
   /**
@@ -249,10 +248,8 @@ class BlockEditorController {
 
   /**
    * Update the generator code.
-   * @private
    */
-  updateGenerator_() {
-    // REFACTORED: Moved in from factory.js:updateGenerator()
+  updateGenerator() {
     const language = $('#language').val();
     const generatorStub = FactoryUtils.getGeneratorStub(
         this.getPreviewBlock_(), language);
@@ -286,7 +283,7 @@ class BlockEditorController {
   }
 
   /**
-   * Update the preview display.
+   * Update the preview workspace with the updated block.
    */
   updatePreview() {
     // REFACTORED: Moved in from factory.js:updatePreview()
@@ -314,7 +311,7 @@ class BlockEditorController {
       this.renderPreviewBlock_(blockType);
     } catch(err) {
       // TODO: Show error on the UI
-      console.log(err);
+      console.error(err);
     } finally {
       Blockly.Blocks = backupBlocks;
       this.view.blockDefinition.undefine();

--- a/src/controller/project_controller.js
+++ b/src/controller/project_controller.js
@@ -120,7 +120,7 @@ class ProjectController {
    */
   createBlockDefinition(blockType, libraryName) {
     //TODO #105: check for valid name, throw error upon conflict
-    const block = new BlockDefinition(blockType);
+    const block = new BlockDefinition(blockType, 'JSON');
     this.addBlockDefinition(block, libraryName);
     return block;
   }

--- a/src/controller/read_write_controller.js
+++ b/src/controller/read_write_controller.js
@@ -414,7 +414,7 @@ document.onload = function() {
     this.appController.projectController.addBlockLibrary(library);
     for (let blockJson of jsonArray) {
       let xml = Blockly.Xml.textToDom(buddyXml[blockJson.type]);
-      let block = new BlockDefinition(blockJson.type, JSON.stringify(blockJson));
+      let block = new BlockDefinition(blockJson.type, 'JSON', JSON.stringify(blockJson));
       block.setXml(xml);
       block.define();
       this.appController.editorController.blockEditorController.view.show(block);

--- a/src/model/block_definition.js
+++ b/src/model/block_definition.js
@@ -27,47 +27,90 @@ goog.provide('BlockDefinition');
  *     purposes of the DevTools Application.
  */
 class BlockDefinition extends Resource {
-// TODO: add methods, fields, etc.
   /**
    * BlockDefinition Class.
    * @constructor
-   * @param {string} type The name of the block.
-   * @param {string=} opt_json optional String representation block definition
-   *     JSON.
+   * @param {string} blockTypeName The type name of the definition, used as a
+   *                               key in Blockly.Blocks.
+   * @param {string} format The format of the definition. Either 'JSON' or
+   *                        'JS'.
+   * @param {string=} opt_defStr Optional string representation block
+   *                             definition, in the declared format.
+   * @param {Element} opt_xml Optional XML DOM representing the block (to be
+   *                          removed).
+   *
+   * @throws If format is not either 'JSON' or 'JS'.
    */
-  constructor(type, opt_json) {
-    super(type, PREFIXES.BLOCK);
+  // TODO(#260): Remove opt_xml.
+  constructor(blockTypeName, format, opt_defStr, opt_xml) {
+    super(blockTypeName, PREFIXES.BLOCK);
 
     /**
      * XML Element of blocks displayed on Block Editor workspace.
      * @type {!Element}
      */
+    // TODO(#260): Remove.
     this.xml = Blockly.Xml.textToDom('<xml></xml>');
 
     /**
-     * The JSON representation of the block.
+     * The JSON string representation of the block.
      * @type {string}
      */
-    this.json = opt_json || this.createStarterJson();
+    this.json_ = null;
+
+    /**
+     * The JavaScript string representation of the block.
+     * @type {string}
+     */
+    this.javascript_ = null;
+
+    this.update(format, opt_defStr, opt_xml)
+  }
+
+  /**
+   * Updates the block definition from a JSON string.
+   * @param {string} format The format of the definition. Either 'JSON' or 'JS'.`
+   * @param {string=} opt_defStr optional String representation block definition.
+   * @param {Element} opt_xml optional XML string representing the block (to be removed).
+   * @throws If format is not either 'JSON' or 'JS'.
+   */
+  update(format, opt_defStr, opt_xml) {
+    const formatCaps = format.toUpperCase();
+    if (formatCaps === 'JSON') {
+      this.json_ = opt_defStr || this.createStarterJson_();
+    } else if (formatCaps === 'JS') {
+      this.javascript_ = opt_defStr || this.createStarterJavaScript_();
+    } else {
+      throw new Error('Unrecognized BlockDefinition format specifier: ' + format);
+    }
+
+    // TODO(#260): Remove
+    this.xml = opt_xml || Blockly.Xml.textToDom('<xml></xml>');
   }
 
   /**
    * Defines block by adding it to the Blockly.Blocks map. Previous entry in
    * Blockly.Blocks map is overwritten if the block has already been defined before.
-   * @throws If BlockDefinition object is unnamed.
+   *
+   * @throws If this.name is not valid.
+   * @throws If cannot parse a JSON definition.
+   * @throws If JavaScript eval throws, or does not generated the named block definition.
+   * @throws If no definition string is found.
    */
   define() {
     if (!this.name) {
-      throw 'Block definition does not have a valid name. Cannot be added to ' +
-          'Blockly.Blocks map.';
-      return;
+      throw new Error(
+        'Block definition does not have a valid name. Cannot be added to ' +
+        'Blockly.Blocks map.');
     }
-    const json = JSON.parse(this.json);
-    Blockly.Blocks[this.name] = {
-      init: function() {
-        this.jsonInit(json);
-      }
-    };
+
+    if (this.json_) {
+      this.defineFromJson_();
+    } else if (this.javascript_) {
+      this.defineFromJavaScript_();
+    } else {
+      throw new Error('Illegal state in BlockDefinition: No definition string found.');
+    }
   }
 
   /**
@@ -80,10 +123,65 @@ class BlockDefinition extends Resource {
   }
 
   /**
+   * Defines block from JSON string, adding it to the Blockly.Blocks map.
+   * Previous entry in Blockly.Blocks map is overwritten if the block has
+   * already been defined before.
+   *
+   * @throws If cannot parse the JSON definition.
+   * @private
+   */
+  defineFromJson_() {
+    const typeName = this.type();
+    try {
+      var jsonObj = JSON.parse(this.json_);
+    } catch(jsonParseError) {
+      console.log('BlockDefinition \"' + typeName + '\" JSON:', this.json_);
+      throw jsonParseError;
+    }
+
+    jsonObj.name = typeName;
+
+    Blockly.Blocks[typeName] = {
+      init: function() {
+        this.jsonInit(jsonObj);
+      }
+    };
+  }
+
+  /**
+   * Defines block from JavaScript string, adding it to the Blockly.Blocks map.
+   * Previous entry in Blockly.Blocks map is overwritten if the block has
+   * already been defined before.
+   *
+   * @throws If JavaScript eval throws.
+   * @throws If JavaScript does not generated the expected block definition.
+   */
+  defineFromJavaScript_() {
+    try {
+      // TODO(#278): Evaluate this definition in a sandbox / interpreter.
+      eval(this.javascript_);
+    } catch (e) {
+      // TODO: Display evaluation error in the UI
+
+      // Log the full stack trace of the error.
+      console.error(
+        'Error while evaluating JavaScript formatted block definition', e);
+      undefine();  // Attempt to reset state.
+      throw new Error('Failed to define block type from JavaScript.');
+    }
+
+    if (!Blockly.Blocks[name]) {
+      throw new Error('Evaluating JavaScript did not define a block type named "'
+          + name + '".');
+    }
+  }
+
+  /**
    * Creates starter JSON for the block if no JSON has been provided.
    * @return {!Object} JSON with a defined type and message0 field.
+   * @private
    */
-  createStarterJson() {
+  createStarterJson_() {
     var blockJson = Object.create(null);
     blockJson.type = this.type();
     blockJson.message0 = '';
@@ -91,8 +189,22 @@ class BlockDefinition extends Resource {
   }
 
   /**
+   * Creates starter JavaScript for the block if no definition has been provided.
+   * @return {!Object} JSON with a defined type and message0 field.
+   * @private
+   */
+  createStarterJavaScript_() {
+    return `
+Blockly.Blocks['${this.type()}'] = {
+  init: function() {
+    // Definition calls go here.
+  }
+};`;
+  }
+
+  /**
    * Returns the type of the block.
-   * @return {string} The block type.
+   * @return {string} The type name of the definition.
    */
   type() {
     return this.name;
@@ -100,12 +212,12 @@ class BlockDefinition extends Resource {
 
   /**
    * Sets type of BlockDefinition to new name.
-   * @param {string} type New type name of block.
+   * @param {string} blockTypeName The type name of the definition.
    */
-  setType(type) {
+  setType(blockTypeName) {
     // TODO(#180): Remove references to setType() to be setName() to follow object
     // inheritance.
-    this.setName(type);
+    this.setName(blockTypeName);
   }
 
   /**

--- a/src/view/block_editor_view.js
+++ b/src/view/block_editor_view.js
@@ -167,7 +167,7 @@ class BlockEditorView {
 
     // Update code generator
     $('#language').change(() => {
-      controller.updateGenerator_();
+      controller.updateGenerator();
     });
   }
 


### PR DESCRIPTION
Adding .javascript_ field to support block definitions defined in
JavaScript. Adding a format string parameter (either 'JSON' or
'JS) to many of the methods.

Next step:
Updates to JSON definition are still not updating the preview.
Check BlockEditorController.updatePreview() or .refreshPreview().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/284)
<!-- Reviewable:end -->
