### PR TITLE
Manual mode: Changes in the editor workspace do not update the input textarea (languageTA).

### DIFF
--- a/src/view/block_editor_view.js
+++ b/src/view/block_editor_view.js
@@ -143,7 +143,7 @@ class BlockEditorView {
    */
   init(controller) {
     this.editorWorkspace.addChangeListener((event) => {
-      controller.onChange(event);
+      controller.onWorkspaceChange(event);
     });
 
     // LTR <-> RTL
@@ -169,6 +169,13 @@ class BlockEditorView {
     $('#language').change(() => {
       controller.updateGenerator();
     });
+  }
+
+  /**
+   * Whether the currently selected mode is a manual editing mode.
+   */
+  isInManualMode() {
+    return $('#format').val() == BlockEditorController.FORMAT_MANUAL;
   }
 
   /**


### PR DESCRIPTION
I think this circumvents the need for JCO's `BlockFactory.updateBlocksFlag` and `.updateBlocksFlagDelayed`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/285)
<!-- Reviewable:end -->
