### PR TITLE
Re-adding copy of Blockly.Blocks.

### DIFF
--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -303,6 +303,12 @@ class BlockEditorController {
     // collide if user creates a 'factory_base' block, for instance.
     const backupBlocks = Blockly.Blocks;
     try {
+      // Make a shallow copy.
+      Blockly.Blocks = Object.create(null);
+      for (var prop in backupBlocks) {
+        Blockly.Blocks[prop] = backupBlocks[prop];
+      }
+
       // Evaluates block definition (temporarily) for preview.
       this.view.blockDefinition.define();
 


### PR DESCRIPTION
backupBlocks allows the editor to work with blocks that might
be named the same as the blocks in the Blockly editor itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/288)
<!-- Reviewable:end -->
