### PR TITLE
Renaming HTML ids, fields, and methods for clarity.

### DIFF
--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -163,7 +163,7 @@ class BlockEditorController {
    * Refreshes previews in view and updates model.
    */
   refreshPreviews() {
-    const format = $('#format').val();
+    const format = this.view.formatSelector_.val();
     this.updateBlockDefinitionView_(format);
     this.updatePreview();
     this.updateGenerator();
@@ -175,34 +175,35 @@ class BlockEditorController {
   changeFormat() {
     // From factory.js:formatChange()
     // TODO(#168): Move to view class and fix references.
-    const mask = $('#blocklyMask');
-    const languagePre = $('#languagePre');
-    const languageTA = $('#languageTA');
+    const editorMask = this.view.editorMask_;
+    const blockDefPre = this.view.blockDefPre_;
+    const manualBlockDefTA = this.view.manualBlockDefTA_;
 
     // TODO(#168): Avoid view reference by passing in inManualMode arugment.
     this.inManualMode_ = this.view.isInManualMode();
     if (this.inManualMode_) {
       Blockly.hideChaff();
-      mask.show();
-      languagePre.hide();
+      editorMask.show();
+      blockDefPre.hide();
       // .show() will set this to inline-block, which won't size correctly.
-      languageTA.css('display', 'block');
-      const code = languagePre.text().trim();
-      languageTA.val(code);
-      languageTA.focus();
+      manualBlockDefTA.css('display', 'block');
+      const code = blockDefPre.text().trim();
+      manualBlockDefTA.val(code);
+      manualBlockDefTA.focus();
       this.updatePreview();
     } else {
-      mask.hide();
-      languageTA.hide();
-      languagePre.show();
-      this.updateLanguage();
+      editorMask.hide();
+      manualBlockDefTA.hide();
+      blockDefPre.show();
+      this.updateBlockDefPre();
+      this.updatePreview();
     }
   }
 
   /**
    * Update the block definition code based on constructs made in Blockly.
    */
-  updateLanguage() {
+  updateBlockDefPre() {
     var rootBlock = FactoryUtils.getRootBlock(this.view.editorWorkspace);
     if (!rootBlock) {
       return;
@@ -214,8 +215,7 @@ class BlockEditorController {
     var format = document.getElementById('format').value;
     var code = FactoryUtils.getBlockDefinition(format,
         this.view.editorWorkspace);
-    FactoryUtils.injectCode(code, 'languagePre');
-    this.updatePreview();
+    FactoryUtils.injectCode(code, 'blockDefPre');
   }
 
   /**
@@ -280,7 +280,7 @@ class BlockEditorController {
    * Update the generator code.
    */
   updateGenerator() {
-    const language = $('#language').val();
+    const language = $('#language').val();  // Output code language
     const generatorStub = FactoryUtils.getGeneratorStub(
         this.getPreviewBlock_(), language);
     this.view.updateGenStub(generatorStub);
@@ -293,7 +293,7 @@ class BlockEditorController {
    */
   updateBlockDefinitionView_(format) {
     if (format == BlockEditorController.FORMAT_MANUAL) {
-      const defCode = $('#languagePre').val();
+      const defCode = this.view.blockDefPre_.val();
       this.view.updateBlockDefinitionView(defCode, /* opt_manual */ true);
     } else {
       const currentBlock = this.view.blockDefinition;
@@ -365,9 +365,9 @@ class BlockEditorController {
     const blockDef = [];
 
     // Fetch the code and determine its format (JSON or JavaScript).
-    let format = $('#format').val();
+    let format = this.view.formatSelector_.val();
     if (format == BlockEditorController.FORMAT_MANUAL) {
-      var code = $('#languageTA').val();
+      var code = this.view.manualBlockDefTA_.val();
       // If the code is JSON, it will parse, otherwise treat as JS.
       try {
         JSON.parse(code);
@@ -376,7 +376,7 @@ class BlockEditorController {
         format = BlockEditorController.FORMAT_JAVASCRIPT;
       }
     } else {
-      var code = $('#languagePre').text();
+      var code = this.view.blockDefPre_.text();
     }
 
     blockDef.push(format);

--- a/src/factory.css
+++ b/src/factory.css
@@ -77,14 +77,14 @@ input {
   height: 10%;
 }
 
-#blockly {
+#blockEditorWorkspace {
   height: 100%;
   position: relative;
   width: 100%;
   z-index: 10;
 }
 
-#blocklyMask {
+#blockEditorWorkspaceMask {
   background-color: #000;
   bottom: 0;
   cursor: not-allowed;
@@ -103,7 +103,7 @@ input {
 }
 
 pre,
-#languageTA {
+#manualBlockDefTA {
   border: #ddd 1px solid;
   box-sizing: border-box;
   height: 100%;
@@ -112,8 +112,8 @@ pre,
   width:100%;
 }
 
-#languageTA {
-  display: none;
+#manualBlockDefTA {
+  display: none; /* Initial state */
   font: 10pt monospace;
   resize: none;
 }

--- a/src/view/app_view.js
+++ b/src/view/app_view.js
@@ -492,18 +492,20 @@ class AppView {
   /**
    * Add event listeners for the block factory.
    */
-  // TODO(#276): Move to BlockEditorView or Controller.
+  // TODO(#276): Move to BlockEditorView.
   addBlockFactoryEventListeners() {
     const controller =
         this.appController.editorController.blockEditorController;
     const changeFormat = controller.changeFormat.bind(controller);
-    const updateLanguage = controller.updateLanguage.bind(controller);
+    const updateBlockDefPre = controller.updateBlockDefPre.bind(controller);
     const updatePreview = controller.updatePreview.bind(controller);
     const refreshPreviews = controller.refreshPreviews.bind(controller);
 
     // Update code on changes to block being edited.
-    this.blockEditorView.editorWorkspace.addChangeListener(
-        updateLanguage);
+    this.blockEditorView.editorWorkspace.addChangeListener(() => {
+      updateBlockDefPre();
+      updatePreview();
+    });
 
     // Disable blocks not attached to the factory_base block.
     this.blockEditorView.editorWorkspace.addChangeListener(
@@ -514,8 +516,8 @@ class AppView {
         refreshPreviews);
 
     $('#direction').change(updatePreview);
-    $('#languageTA').change(updatePreview);
-    $('#languageTA').keyup(updatePreview);
+    $('#manualBlockDefTA').change(updatePreview);
+    $('#manualBlockDefTA').keyup(updatePreview);
     $('#format').change(changeFormat);
     $('#language').change(updatePreview);
   }

--- a/src/view/block_editor_view.js
+++ b/src/view/block_editor_view.js
@@ -71,6 +71,31 @@ class BlockEditorView {
     this.deleteButton = $('#removeBlockFromLibraryButton');
 
     /**
+     * Drop down selector to pick the code format.
+     * @type {!JQuery}
+     */
+    this.formatSelector_ = $('#format');
+
+    /**
+     * Pretty-printed &lt;pre&gt; that displays the JSON or JavaScript code for
+     * the block defined in the workspace.
+     * @type {!JQuery}
+     */
+    this.blockDefPre_ = $('#blockDefPre');
+
+    /**
+     * The textarea to edit the block definition in manual mode.
+     * @type {!JQuery}
+     */
+    this.manualBlockDefTA_ = $('#manualBlockDefTA');
+
+    /**
+     * The overlay to show over the editor workspace to prevent interaction.
+     * @type {!JQuery}
+     */
+    this.editorMask_ = $('#blockEditorWorkspaceMask');
+
+    /**
      * Whether user is creating RTL or LTR blocks.
      * @type {boolean}
      */
@@ -80,7 +105,7 @@ class BlockEditorView {
      * Blockly workspace of main block defining workspace.
      * @type {!Blockly.Workspace}
      */
-    this.editorWorkspace = Blockly.inject('blockly',
+    this.editorWorkspace = Blockly.inject('blockEditorWorkspace',
       {
         collapse: false,
         toolbox: DevToolsToolboxes.blockFactory,
@@ -158,10 +183,11 @@ class BlockEditorView {
     });
 
     // Update preview as user manually defines block.
-    $('#languageTA').on('input', () => {
+    let manualBlockDefTA = $('#manualBlockDefTA');
+    manualBlockDefTA.on('input', () => {
       controller.updatePreview();
     });
-    $('#languageTA').on('keyup', () => {
+    manualBlockDefTA.on('keyup', () => {
       controller.updatePreview();
     });
 
@@ -223,13 +249,13 @@ class BlockEditorView {
   updateBlockDefinitionView(blockDefCode, opt_manual) {
     if (opt_manual) {
       // If manual edit.
-      $('#languagePre').hide();
-      $('#languageTA').show();
-      $('#languageTA').val(blockDefCode);
+      this.blockDefPre_.hide();
+      this.manualBlockDefTA_.show();
+      this.manualBlockDefTA_.val(blockDefCode);
     } else {
-      $('#languagePre').show();
-      $('#languageTA').hide();
-      FactoryUtils.injectCode(blockDefCode, 'languagePre');
+      this.blockDefPre_.show();
+      this.manualBlockDefTA_.hide();
+      FactoryUtils.injectCode(blockDefCode, 'blockDefPre');
     }
   }
 
@@ -320,8 +346,8 @@ BlockEditorView.html = `
 <table id="blockEditor">
   <tr height="100%">
     <td id="blocklyWorkspaceContainer">
-      <div id="blockly"></div>
-      <div id="blocklyMask"></div>
+      <div id="blockEditorWorkspace"></div>
+      <div id="blockEditorWorkspaceMask"></div>
     </td>
     <td width="50%">
       <table id="blocklyPreviewContainer">
@@ -353,8 +379,8 @@ BlockEditorView.html = `
         </tr>
         <tr>
           <td height="30%">
-            <pre id="languagePre"></pre>
-            <textarea id="languageTA"></textarea>
+            <pre id="blockDefPre"></pre>
+            <textarea id="manualBlockDefTA"></textarea>
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
#languagePre => #blockDefPre
#languageTA => #manualBlockDefTA
#mask => #editorMask
updateLanguage() => updateBlockDefPre()

Also, adding the following JQuery references to BlockEditorView:
 .blockDefPre_
 .manualBlockDefTA_
 .editorMask_
 .formatSelector_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/289)
<!-- Reviewable:end -->
