### PR TITLE
Moving all block editor EventListeners into the BlockEditorView.init()

### DIFF
--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -316,13 +316,12 @@ class BlockEditorController {
    * Update the preview workspace with the updated block.
    */
   updatePreview() {
-    // REFACTORED: Moved in from factory.js:updatePreview()
     const newDir = $('#direction').val();
     this.view.updateDirection(newDir);
 
-    const blockDef = this.getDefinitionFormat_();
-    const format = blockDef[0];
-    const code = blockDef[1];
+    const blockFormatCode = this.getBlockFormatCode_();
+    const format = blockFormatCode[0];
+    const code = blockFormatCode[1];
 
     if (!code.trim()) {
       // Nothing to render.  Happens while cloud storage is loading.
@@ -355,13 +354,23 @@ class BlockEditorController {
   }
 
   /**
-   * Determines what format the user-defined block definition is in.
+   * Attempt to update the block definition (model, view, and preview), from a
+   * code string.
+   *
+   * @return {boolean} True if successful. Otherwise false.
+   */
+  attemptUpdateFromManualCode() {
+    // TODO
+    this.updatePreview();
+  }
+
+  /**
+   * Retrieves the current block's format and code.
    * @return {!Array.<string>} Two-element array. First element is format of code,
    *     and second is the block definition code.
    * @private
    */
-  getDefinitionFormat_() {
-    // REFACTORED: Moved in from factory.js:updatePreview()
+  getBlockFormatCode_() {
     const blockDef = [];
 
     // Fetch the code and determine its format (JSON or JavaScript).

--- a/src/controller/editor_controller.js
+++ b/src/controller/editor_controller.js
@@ -121,6 +121,8 @@ class EditorController {
       return;
     }
 
+    // TODO(#291): Add base class BaseEditorController and
+    //             BaseEditorController.saveChanges()
     if (this.currentEditor instanceof BlockEditorController) {
       Blockly.WidgetDiv.hide();
       if (Blockly.selected) {

--- a/src/view/app_view.js
+++ b/src/view/app_view.js
@@ -387,7 +387,6 @@ class AppView {
     this.tabClickHandlers_();
     // Assign general app button click handlers
     this.assignClickHandlers();
-    this.addBlockFactoryEventListeners();
   }
 
   /**
@@ -487,38 +486,5 @@ class AppView {
       this.closeModal_();
       this.appController.createPopup(PopupController.NEW_BLOCK);
     });
-  }
-
-  /**
-   * Add event listeners for the block factory.
-   */
-  // TODO(#276): Move to BlockEditorView.
-  addBlockFactoryEventListeners() {
-    const controller =
-        this.appController.editorController.blockEditorController;
-    const changeFormat = controller.changeFormat.bind(controller);
-    const updateBlockDefPre = controller.updateBlockDefPre.bind(controller);
-    const updatePreview = controller.updatePreview.bind(controller);
-    const refreshPreviews = controller.refreshPreviews.bind(controller);
-
-    // Update code on changes to block being edited.
-    this.blockEditorView.editorWorkspace.addChangeListener(() => {
-      updateBlockDefPre();
-      updatePreview();
-    });
-
-    // Disable blocks not attached to the factory_base block.
-    this.blockEditorView.editorWorkspace.addChangeListener(
-        Blockly.Events.disableOrphans);
-
-    // Update preview on every change.
-    this.blockEditorView.editorWorkspace.addChangeListener(
-        refreshPreviews);
-
-    $('#direction').change(updatePreview);
-    $('#manualBlockDefTA').change(updatePreview);
-    $('#manualBlockDefTA').keyup(updatePreview);
-    $('#format').change(changeFormat);
-    $('#language').change(updatePreview);
   }
 }

--- a/src/view/block_editor_view.js
+++ b/src/view/block_editor_view.js
@@ -167,27 +167,13 @@ class BlockEditorView {
    * @package
    */
   init(controller) {
+    // Update code on changes to block being edited.
     this.editorWorkspace.addChangeListener((event) => {
       controller.onWorkspaceChange(event);
+
+      // Disable blocks not attached to the factory_base block.
+      Blockly.Events.disableOrphans(event);
     });
-
-    const changeFormat = controller.changeFormat.bind(controller);
-    const updatePreview = controller.updatePreview.bind(controller);
-    const refreshPreviews = controller.refreshPreviews.bind(controller);
-
-    // Update code on changes to block being edited.
-    this.editorWorkspace.addChangeListener(() => {
-      controller.updateBlockDefPre();
-      controller.updatePreview();
-    });
-
-    // Disable blocks not attached to the factory_base block.
-    this.editorWorkspace.addChangeListener(
-        Blockly.Events.disableOrphans);
-
-    // Update preview on every change.
-    this.editorWorkspace.addChangeListener(
-        refreshPreviews);
 
     $('#direction').change(() => {
       this.updateDirection($('#direction').val());

--- a/src/view/block_editor_view.js
+++ b/src/view/block_editor_view.js
@@ -171,24 +171,40 @@ class BlockEditorView {
       controller.onWorkspaceChange(event);
     });
 
-    // LTR <-> RTL
+    const changeFormat = controller.changeFormat.bind(controller);
+    const updatePreview = controller.updatePreview.bind(controller);
+    const refreshPreviews = controller.refreshPreviews.bind(controller);
+
+    // Update code on changes to block being edited.
+    this.editorWorkspace.addChangeListener(() => {
+      controller.updateBlockDefPre();
+      controller.updatePreview();
+    });
+
+    // Disable blocks not attached to the factory_base block.
+    this.editorWorkspace.addChangeListener(
+        Blockly.Events.disableOrphans);
+
+    // Update preview on every change.
+    this.editorWorkspace.addChangeListener(
+        refreshPreviews);
+
     $('#direction').change(() => {
       this.updateDirection($('#direction').val());
       controller.updatePreview();
     });
 
-    // JSON <-> JS for Block Definition
-    $('#format').change(() => {
-      controller.changeFormat();
+    // Update preview as user manually defines block.
+    this.manualBlockDefTA_.on('input', () => {
+      controller.attemptUpdateFromManualCode();
+    });
+    this.manualBlockDefTA_.on('keyup', () => {
+      controller.attemptUpdateFromManualCode();
     });
 
-    // Update preview as user manually defines block.
-    let manualBlockDefTA = $('#manualBlockDefTA');
-    manualBlockDefTA.on('input', () => {
-      controller.updatePreview();
-    });
-    manualBlockDefTA.on('keyup', () => {
-      controller.updatePreview();
+    // JSON <-> JS for Block Definition
+    this.formatSelector_.change(() => {
+      controller.changeFormat();
     });
 
     // Update code generator
@@ -327,11 +343,11 @@ class BlockEditorView {
       }
       this.rtl = newDir;
       this.previewWorkspace = Blockly.inject('preview',
-        {
-          rtl: this.rtl,
-          media: 'media/',
-          scrollbars: true
-        });
+          {
+            rtl: this.rtl,
+            media: 'media/',
+            scrollbars: true
+          });
     }
     this.previewWorkspace.clear();
   }

--- a/src/view/block_editor_view.js
+++ b/src/view/block_editor_view.js
@@ -169,10 +169,12 @@ class BlockEditorView {
   init(controller) {
     // Update code on changes to block being edited.
     this.editorWorkspace.addChangeListener((event) => {
-      controller.onWorkspaceChange(event);
-
       // Disable blocks not attached to the factory_base block.
+      // Must do first so newly attached blocks are enabled when they
+      // are processed by the controller code.
       Blockly.Events.disableOrphans(event);
+
+      controller.onWorkspaceChange(event);
     });
 
     $('#direction').change(() => {


### PR DESCRIPTION
Also Renamed `BlockEditorController.getDefinitionFormat_()` to `.getBlockFormatCode_()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/290)
<!-- Reviewable:end -->
