### PR TITLE
Fix #272. Manual edits have immediate preview.

### DIFF
--- a/src/controller/block_editor_controller.js
+++ b/src/controller/block_editor_controller.js
@@ -378,7 +378,7 @@ class BlockEditorController {
       tempDefinition.define();
       this.renderPreviewBlock_(tempBlockType);
     } catch(err) {
-      // TODO: Option to show the error in the UI?
+      // TODO(#293): Option to show the error in the UI?
       console.error(err);
       return false;
     } finally {


### PR DESCRIPTION
Use a temporary BlockDefinition to create the preview, instead of using the saved model from the project.

Also removed unused method getBlockTypeFromXml_(xmlText).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/292)
<!-- Reviewable:end -->
