### PR TITLE
Update the blocks to reflect manual edits.

### DIFF
--- a/src/view/block_editor_view.js
+++ b/src/view/block_editor_view.js
@@ -369,13 +369,13 @@ class BlockEditorView {
    */
   renderPreviewBlock(blockType) {
     // Create the preview block.
-    const previewBlock = this.view.previewWorkspace.newBlock(blockType);
+    const previewBlock = this.previewWorkspace.newBlock(blockType);
     previewBlock.initSvg();
     previewBlock.render();
     previewBlock.setMovable(false);
     previewBlock.setDeletable(false);
     previewBlock.moveBy(15, 10);
-    this.view.previewWorkspace.clearUndo();
+    this.previewWorkspace.clearUndo();
   }
 }
 


### PR DESCRIPTION
Works with both JSON and JavaScript.

Also...
 * Fix a critical copy-pasta error in the BlockEditorView.
 * Centralize block type name extraction. Fixes `'____temporary_block_type_name_for_preview'` showing up in the generator.
 * Rename `getBlockDefinitionCode_()` as `getBlockDefinitionCodeFromBlocks_()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-devtools/301)
<!-- Reviewable:end -->
